### PR TITLE
Add option to completely remove VRT NU resumepoints

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -773,34 +773,38 @@ msgid "Refresh watching activity"
 msgstr ""
 
 msgctxt "#30921"
-msgid "Use menu caching"
-msgstr ""
-
-msgctxt "#30922"
-msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
+msgid "Remove watching activity"
 msgstr ""
 
 msgctxt "#30923"
-msgid "Use local HTTP caching"
+msgid "Use menu caching"
+msgstr ""
+
+msgctxt "#30924"
+msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
 msgstr ""
 
 msgctxt "#30925"
-msgid "Invalidate local HTTP caches"
+msgid "Use local HTTP caching"
 msgstr ""
 
 msgctxt "#30927"
-msgid "Direct HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
+msgid "Invalidate local HTTP caches"
 msgstr ""
 
 msgctxt "#30929"
-msgid "Indirect HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
+msgid "Direct HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
 msgstr ""
 
 msgctxt "#30931"
-msgid "Logging"
+msgid "Indirect HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
 msgstr ""
 
 msgctxt "#30933"
+msgid "Logging"
+msgstr ""
+
+msgctxt "#30935"
 msgid "Log level"
 msgstr ""
 
@@ -912,4 +916,12 @@ msgstr ""
 
 msgctxt "#30986"
 msgid "No on demand stream available for {title}."
+msgstr ""
+
+msgctxt "#30987"
+msgid "Are you sure you want to permantly remove all VRT NU watching activity?"
+msgstr ""
+
+msgctxt "#30988"
+msgid "Successfully removed watching activity."
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -773,34 +773,38 @@ msgid "Refresh watching activity"
 msgstr "Ververs kijkactiviteit"
 
 msgctxt "#30921"
+msgid "Remove watching activity"
+msgstr "Verwijder kijkactiviteit"
+
+msgctxt "#30923"
 msgid "Use menu caching"
 msgstr "Gebruik menu caching"
 
-msgctxt "#30922"
+msgctxt "#30924"
 msgid "When enabled, menus are being cached so they work more quickly. Only in very specific use-cases this is problematic as new episodes may not appear when they are expected. You can also use [B]Refresh[/B] from the context-menu."
 msgstr "Indien geactiveerd worden Kodi menus gecached zodat ze sneller werken. Enkel in heel uitzonderlijke gevallen is het interessanter noodzakelijk om altijd nieuwe episodes te zijn als ze uitkomen. Je kan ook [B]Ververs[/B] gebruiken vanuit het context-menu."
 
-msgctxt "#30923"
+msgctxt "#30925"
 msgid "Use local HTTP caching"
 msgstr "Gebruik lokale HTTP caching"
 
-msgctxt "#30925"
+msgctxt "#30927"
 msgid "Invalidate local HTTP caches"
 msgstr "Maak lokale HTTP caches ongeldig"
 
-msgctxt "#30927"
+msgctxt "#30929"
 msgid "Direct HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
 msgstr "Directe HTTP cache time-to-live [COLOR gray](in minuten)[/COLOR]"
 
-msgctxt "#30929"
+msgctxt "#30931"
 msgid "Indirect HTTP cache time-to-live [COLOR gray](in minutes)[/COLOR]"
 msgstr "Indirecte HTTP cache time-to-live [COLOR gray](in minuten)[/COLOR]"
 
-msgctxt "#30931"
+msgctxt "#30933"
 msgid "Logging"
 msgstr "Logboek"
 
-msgctxt "#30933"
+msgctxt "#30935"
 msgid "Log level"
 msgstr "Log niveau"
 
@@ -913,3 +917,11 @@ msgstr "VRT tokens werden verwijderd."
 msgctxt "#30986"
 msgid "No on demand stream available for {title}."
 msgstr "Geen on demand stream beschikbaar voor {title}"
+
+msgctxt "#30987"
+msgid "Are you sure you want to permantly remove all VRT NU watching activity?"
+msgstr "Ben je zeker dat je alle VRT NU kijkactiviteit permanent wil verwijderen?"
+
+msgctxt "#30988"
+msgid "Successfully removed watching activity."
+msgstr "Kijkactiviteit werd verwijderd."

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -140,6 +140,13 @@ def resumepoints_watchlater():
     VRTPlayer().show_watchlater_menu(page=1)
 
 
+@plugin.route('/resumepoints/remove')
+def resumepoints_remove():
+    """Remove all VRT NU resumepoints online and locally"""
+    from resumepoints import ResumePoints
+    ResumePoints().remove_resumepoints()
+
+
 @plugin.route('/programs')
 @plugin.route('/programs/<program>')
 @plugin.route('/programs/<program>/<season>')

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -307,6 +307,14 @@ def ok_dialog(heading='', message=''):
     return Dialog().ok(heading=heading, line1=message)
 
 
+def yesno_dialog(heading='', message=''):
+    """Show Kodi's Yes/No dialog"""
+    from xbmcgui import Dialog
+    if not heading:
+        heading = addon_name()
+    return Dialog().yesno(heading=heading, line1=message)
+
+
 def notification(heading='', message='', icon='info', time=4000):
     """Show a Kodi notification"""
     from xbmcgui import Dialog

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -70,12 +70,13 @@
         <setting label="30915" help="30916" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/tokens/delete)"/> <!-- Delete tokens -->
         <setting label="30917" help="30918" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/favorites/refresh)"/> <!-- Refresh favorites -->
         <setting label="30919" help="30920" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/resumepoints/refresh)"/> <!-- Refresh resumepoints -->
-        <setting label="30921" help="30922" type="bool" id="usemenucaching" default="true"/>
-        <setting label="30923" help="30924" type="bool" id="usehttpcaching" default="true"/>
-        <setting label="30925" help="30926" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/cache/delete)" enable="eq(-1,true)" subsetting="true"/>
-        <setting label="30927" help="30928" type="slider" id="httpcachettldirect" default="5" range="1,1,240" option="int" enable="eq(-2,true)" subsetting="true"/>
-        <setting label="30929" help="30930" type="slider" id="httpcachettlindirect" default="60" range="1,1,240" option="int" enable="eq(-3,true)" subsetting="true"/>
-        <setting label="30931" type="lsep"/> <!-- Logging -->
-        <setting label="30933" help="30934" type="enum" id="max_log_level" lvalues="30430|30431|30432|30433" default="0"/>
+        <setting label="30921" help="30922" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/resumepoints/remove)"/> <!-- Remove resumepoints -->
+        <setting label="30923" help="30924" type="bool" id="usemenucaching" default="true"/>
+        <setting label="30925" help="30926" type="bool" id="usehttpcaching" default="true"/>
+        <setting label="30927" help="30928" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/cache/delete)" enable="eq(-1,true)" subsetting="true"/>
+        <setting label="30929" help="30930" type="slider" id="httpcachettldirect" default="5" range="1,1,240" option="int" enable="eq(-2,true)" subsetting="true"/>
+        <setting label="30931" help="30932" type="slider" id="httpcachettlindirect" default="60" range="1,1,240" option="int" enable="eq(-3,true)" subsetting="true"/>
+        <setting label="30933" type="lsep"/> <!-- Logging -->
+        <setting label="30935" help="30936" type="enum" id="max_log_level" lvalues="30430|30431|30432|30433" default="0"/>
     </category>
 </settings>


### PR DESCRIPTION
The add-on can't update resumepoints for programs like "Het goeie leven" (https://www.vrt.be/vrtnu/a-z/het-goeie-leven/) that don't have an `assetPath` in VRT NU Search API.
When users watch these programs on the VRT NU **website** and continue watching at a later point in the **add-on**, these programs are not updated and never removed from the add-on.

Currently, this feature removes all resumepoints! Suggested changes or improvements:
- Only remove entries that are no longer offered by VRT NU
- Only remove entries of which the resume position is not within expected range (e.g. not between 30 and -30) and has `watchLater` set to False
