### PR TITLE
Allow coverage steps to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,16 @@ jobs:
       run: coverage run -a tests/run.py /
     - name: Upload code coverage to CodeCov
       uses: codecov/codecov-action@v1
+      continue-on-error: true
+    - name: Prepare for SonarCloud
+      run: |
+        cat <<EOF >.sonarcloud.properties
+        sonar.organization=Add-ons
+        sonar.projectKey=${{ github.repository }}
+        EOF
     - name: Analyze with SonarCloud
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      continue-on-error: true


### PR DESCRIPTION
This is to ensure that our required pipelines are not blocked because of
Codecov or Sonarcloud availability issues.