### PR TITLE
Ensure codebase is compatible with Kodi 19

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -304,7 +304,9 @@ def ok_dialog(heading='', message=''):
     from xbmcgui import Dialog
     if not heading:
         heading = addon_name()
-    return Dialog().ok(heading=heading, line1=message)
+    if kodi_version_major() < 19:
+        return Dialog().ok(heading=heading, line1=message)
+    return Dialog().ok(heading=heading, message=message)
 
 
 def notification(heading='', message='', icon='info', time=4000):
@@ -645,8 +647,13 @@ def has_credentials():
 
 
 def kodi_version():
-    """Returns major Kodi version"""
-    return int(xbmc.getInfoLabel('System.BuildVersion').split('.')[0])
+    """Returns full Kodi version as string"""
+    return xbmc.getInfoLabel('System.BuildVersion').split(' ')[0]
+
+
+def kodi_version_major():
+    """Returns major Kodi version as integer"""
+    return int(kodi_version().split('.')[0])
 
 
 def can_play_drm():
@@ -656,7 +663,7 @@ def can_play_drm():
 
 def supports_drm():
     """Whether this Kodi version supports DRM decryption using InputStream Adaptive"""
-    return kodi_version() > 17
+    return kodi_version_major() > 17
 
 
 def get_tokens_path():

--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -9,7 +9,7 @@ from xbmc import getInfoLabel, Player, PlayList
 from apihelper import ApiHelper
 from data import CHANNELS
 from favorites import Favorites
-from kodiutils import addon_id, get_setting_bool, has_addon, kodi_version, log, notify, set_property
+from kodiutils import addon_id, get_setting_bool, has_addon, kodi_version_major, log, notify, set_property
 from resumepoints import ResumePoints
 from utils import play_url_to_id, to_unicode, url_to_episode
 
@@ -31,7 +31,7 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         self.asset_id = None
         # FIXME On Kodi 17, use ListItem.Filenameandpath because Player.FilenameAndPath returns the stream manifest url and
         # this definitely breaks "Up Next" on Kodi 17, but this is not supported or available through the Kodi add-on repo anyway
-        self.path_infolabel = 'ListItem.Filenameandpath' if kodi_version() < 18 else 'Player.FilenameAndPath'
+        self.path_infolabel = 'ListItem.Filenameandpath' if kodi_version_major() < 18 else 'Player.FilenameAndPath'
         self.path = None
         self.title = None
         self.ep_id = None
@@ -94,7 +94,7 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         self.whatson_id = episode.get('whatsonId') or None  # Avoid empty string
 
         # Kodi 17 doesn't have onAVStarted
-        if kodi_version() < 18:
+        if kodi_version_major() < 18:
             self.onAVStarted()
 
     def onAVStarted(self):  # pylint: disable=invalid-name

--- a/resources/lib/streamservice.py
+++ b/resources/lib/streamservice.py
@@ -15,7 +15,7 @@ except ImportError:  # Python 2
 from helperobjects import ApiData, StreamURLS
 from kodiutils import (addon_profile, can_play_drm, container_reload, exists, end_of_directory, get_max_bandwidth,
                        get_proxies, get_setting_bool, get_url_json, has_inputstream_adaptive,
-                       invalidate_caches, kodi_version, localize, log, log_error, mkdir, ok_dialog, open_settings,
+                       invalidate_caches, kodi_version_major, localize, log, log_error, mkdir, ok_dialog, open_settings,
                        supports_drm, to_unicode)
 
 
@@ -288,7 +288,7 @@ class StreamService:
        """
         # HLS AES DRM failed
         if protocol == 'hls_aes' and not supports_drm():
-            message = localize(30962, protocol=protocol.upper(), version=kodi_version())
+            message = localize(30962, protocol=protocol.upper(), version=kodi_version_major())
         elif protocol == 'hls_aes' and not has_inputstream_adaptive() and not get_setting_bool('usedrm', default=True):
             message = localize(30958, protocol=protocol.upper(), component=localize(30959), state=localize(30961))
         elif protocol == 'hls_aes' and has_inputstream_adaptive():

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -105,8 +105,8 @@ class VRTPlayer:
         addon_version = get_addon_info('version')
 
         # Compare versions (settings_version was not present in version 1.10.0 and older)
-        settings_comp = tuple(map(int, settings_version.split('.'))) if settings_version != '' else (1, 10, 0)
-        addon_comp = tuple(map(int, addon_version.split('.')))
+        settings_comp = tuple(map(int, settings_version.split('+')[0].split('.'))) if settings_version != '' else (1, 10, 0)
+        addon_comp = tuple(map(int, addon_version.split('+')[0].split('.')))
 
         if addon_comp > settings_comp:
             # New version found, save addon version to settings

--- a/tests/xbmcgui.py
+++ b/tests/xbmcgui.py
@@ -52,11 +52,11 @@ class Dialog:
         print('\033[37;44;1mNOTIFICATION:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, message))
 
     @staticmethod
-    def ok(heading, line1, line2=None, line3=None):
+    def ok(heading, message='', line1='', line2='', line3=''):
         """A stub implementation for the xbmcgui Dialog class ok() method"""
         heading = kodi_to_ansi(heading)
-        line1 = kodi_to_ansi(line1)
-        print('\033[37;44;1mOK:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, line1))
+        message = kodi_to_ansi(message)
+        print('\033[37;44;1mOK:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, message or line1))
 
     @staticmethod
     def info(listitem):
@@ -87,11 +87,11 @@ class Dialog:
         return -1
 
     @staticmethod
-    def yesno(heading, line1, line2=None, line3=None, nolabel=None, yeslabel=None, autoclose=0):
+    def yesno(heading, message='', line1='', line2='', line3='', nolabel=None, yeslabel=None, autoclose=0):
         """A stub implementation for the xbmcgui Dialog class yesno() method"""
         heading = kodi_to_ansi(heading)
-        line1 = kodi_to_ansi(line1)
-        print('\033[37;44;1mYESNO:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, line1))
+        message = kodi_to_ansi(message)
+        print('\033[37;44;1mYESNO:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, message or line1))
         return True
 
     @staticmethod
@@ -105,7 +105,7 @@ class Dialog:
     def browseSingle(type, heading, shares, mask=None, useThumbs=None, treatAsFolder=None, defaultt=None):  # pylint: disable=redefined-builtin
         """A stub implementation for the xbmcgui Dialog class browseSingle() method"""
         print('\033[37;44;1mBROWSESINGLE:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (type, heading))
-        return 'special://masterprofile/addon_data/script.module.inputstreamhelper/'
+        return 'special://masterprofile/addon_data/plugin.video.vrt.nu/'
 
 
 class DialogProgress:
@@ -113,38 +113,38 @@ class DialogProgress:
 
     def __init__(self):
         """A stub constructor for the xbmcgui DialogProgress class"""
-        self.percentage = 0
+        self.percent = 0
 
     def close(self):
         """A stub implementation for the xbmcgui DialogProgress class close() method"""
-        self.percentage = 0
+        self.percent = 0
         print()
         sys.stdout.flush()
 
-    def create(self, heading, line1, line2=None, line3=None):
+    def create(self, heading, message='', line1='', line2='', line3=''):
         """A stub implementation for the xbmcgui DialogProgress class create() method"""
-        self.percentage = 0
+        self.percent = 0
         heading = kodi_to_ansi(heading)
         line1 = kodi_to_ansi(line1)
-        print('\033[37;44;1mPROGRESS:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, line1))
+        print('\033[37;44;1mPROGRESS:\033[35;49;1m [%s] \033[37;1m%s\033[39;0m' % (heading, message or line1))
         sys.stdout.flush()
 
-    @staticmethod
-    def iscanceled():
+    def iscanceled(self):
         """A stub implementation for the xbmcgui DialogProgress class iscanceled() method"""
+        return self.percent > 5  # Cancel at 5%
 
-    def update(self, percentage, line1=None, line2=None, line3=None):
+    def update(self, percent, message='', line1='', line2='', line3=''):
         """A stub implementation for the xbmcgui DialogProgress class update() method"""
-        if (percentage - 5) < self.percentage:
+        if (percent - 5) < self.percent:
             return
-        self.percentage = percentage
+        self.percent = percent
         line1 = kodi_to_ansi(line1)
         line2 = kodi_to_ansi(line2)
         line3 = kodi_to_ansi(line3)
         if line1 or line2 or line3:
-            print('\033[1G\033[37;44;1mPROGRESS:\033[35;49;1m [%d%%] \033[37;1m%s\033[39;0m' % (percentage, line1 or line2 or line3), end='')
+            print('\033[1G\033[37;44;1mPROGRESS:\033[35;49;1m [%d%%] \033[37;1m%s\033[39;0m' % (percent, message or line1 or line2 or line3), end='')
         else:
-            print('\033[1G\033[37;44;1mPROGRESS:\033[35;49;1m [%d%%]\033[39;0m' % (percentage), end='')
+            print('\033[1G\033[37;44;1mPROGRESS:\033[35;49;1m [%d%%]\033[39;0m' % (percent), end='')
         sys.stdout.flush()
 
 
@@ -183,25 +183,10 @@ class DialogProgressBG:
             print('\033[1G\033[37;44;1mPROGRESS:\033[35;49;1m [%d%%]\033[39;0m' % (percentage), end='')
 
 
-class DialogBusy:
-    """A reimplementation of the xbmcgui DialogBusy"""
-
-    def __init__(self):
-        """A stub constructor for the xbmcgui DialogBusy class"""
-
-    @staticmethod
-    def close():
-        """A stub implementation for the xbmcgui DialogBusy class close() method"""
-
-    @staticmethod
-    def create():
-        """A stub implementation for the xbmcgui DialogBusy class create() method"""
-
-
 class ListItem:
     """A reimplementation of the xbmcgui ListItem class"""
 
-    def __init__(self, label='', label2='', iconImage='', thumbnailImage='', path='', offscreen=False):
+    def __init__(self, label='', label2='', path='', offscreen=False):
         """A stub constructor for the xbmcgui ListItem class"""
         self.label = kodi_to_ansi(label)
         self.label2 = kodi_to_ansi(label2)


### PR DESCRIPTION
This pull request includes:
- ignore local version identifier when checking add-on version (for add-on versions that contain +matrix.1)
-  add compatibility with Kodi 19 Python API while preserving backwards compatibility with earlier Kodi versions: https://forum.kodi.tv/showthread.php?tid=344263&pid=2933596#pid2933596