### PR TITLE
Add better add-on tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 .github/ export-ignore
 tests/ export-ignore
-.coverage export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .pylintrc export-ignore

--- a/.github/workflows/addon-check.yml
+++ b/.github/workflows/addon-check.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install --upgrade pip
         # FIXME: Requires changes from xbmc/addon-check#217
         #pip install kodi-addon-checker
-        pip install git+git://github.com/dagwieers/addon-check.git@retry-repo#egg=kodi-addon-checker
+        pip install git+git://github.com/xbmc/addon-check.git@master
     - name: Remove unwanted files
       run: awk '/export-ignore/ { print $1 }' .gitattributes | xargs rm -rf --
       working-directory: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
       with:
         organization: add-ons
         projectKey: add-ons_plugin.video.vrt.nu
-        sources: resources/lib/
-        tests: tests/
-        verbose: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -35,6 +35,9 @@ jobs:
       run: python -m unittest -v test_search.TestSearch.test_search_journaal
     - name: TEST Suggest
       run: python -m unittest -v test_apihelper.TestApiHelper.test_get_tvshows
+    # FIXME: Add a better test for testing EPG
+    - name: TEST TV guide
+      run: python -m unittest -v test_tvguide.TestTVGuide.test_livetv_description
     # FIXME: Add a better test for the webscraper that prints the categories as well
     - name: TEST Categories webscraper
       run: python -m unittest -v test_webscraper.TestWebScraper.test_get_categories

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,6 @@ check-addon: clean
 	kodi-addon-checker . --branch=krypton
 	kodi-addon-checker . --branch=leia
 
-check-codecov:
-	@echo -e "$(white)=$(blue) Test codecov.yml syntax$(reset)"
-	curl --data-binary @codecov.yml https://codecov.io/validate
-
 kill-proxy:
 	-pkill -ef '$(PYTHON) -m proxy'
 
@@ -80,6 +76,7 @@ build: clean
 	@echo -e "$(white)=$(blue) Successfully wrote package as: $(white)../$(zip_name)$(reset)"
 
 clean:
+	@echo -e "$(white)=$(blue) Cleaning up$(reset)"
 	find . -name '*.py[cod]' -type f -delete
 	find . -name '__pycache__' -type d -delete
 	rm -rf .pytest_cache/ .tox/

--- a/resources/lib/resumepoints.py
+++ b/resources/lib/resumepoints.py
@@ -75,10 +75,11 @@ class ResumePoints:
         # Update
         if (self.still_watching(position, total) or watch_later is True
                 or (path and path.startswith('plugin://plugin.video.vrt.nu/play/upnext'))):
-            # Normally, VRT NU resumepoints are deleted when an episode is (un)watched and Kodi GUI automatically sets the (un)watched status when Kodi Player exits.
-            # This mechanism doesn't work with "Up Next" episodes because these episodes are not initiated from a ListItem in Kodi GUI.
-            # For "Up Next" episodes, we should never delete the VRT NU resumepoints to make sure the watched status can be forced in Kodi GUI using the playcount infolabel.
-
+            # Normally, VRT NU resumepoints are deleted when an episode is (un)watched and Kodi GUI automatically sets
+            # the (un)watched status when Kodi Player exits. This mechanism doesn't work with "Up Next" episodes because
+            # these episodes are not initiated from a ListItem in Kodi GUI.
+            # For "Up Next" episodes, we should never delete the VRT NU resumepoints to make sure the watched status
+            # can be forced in Kodi GUI using the playcount infolabel.
             log(3, "[Resumepoints] Update resumepoint '{asset_id}' {position}/{total}", asset_id=asset_id, position=position, total=total)
 
             if asset_id is None:

--- a/tests/test_tvguide.py
+++ b/tests/test_tvguide.py
@@ -69,11 +69,11 @@ class TestTVGuide(unittest.TestCase):
     def test_livetv_description(self):
         """Test Live TV description"""
         description = self._tvguide.live_description('een')
-        print(kodi_to_ansi(description))
+        print('=== Eén ===\n' + kodi_to_ansi(description))
         description = self._tvguide.live_description('canvas')
-        print(kodi_to_ansi(description))
+        print('=== Canvas ===\n' + kodi_to_ansi(description))
         description = self._tvguide.live_description('ketnet')
-        print(kodi_to_ansi(description))
+        print('=== Ketnet ===\n' + kodi_to_ansi(description))
 
     def test_tvguide_all(self):
         """Test episode menu"""


### PR DESCRIPTION
This PR includes:
- Removal of local .coverage file
- Use upstream kodi-addon-checker
- Make sonarcloud checker more silent
- Add EPG testing
- Remove codecov checker
- Add ondemand tests without drm/ia

(Not yet sure this improves coverage, or even works from US)