### PR TITLE
Handle HTTP 431 (Request header fields too large)

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -915,7 +915,7 @@ msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) 
 msgstr ""
 
 msgctxt "#30967"
-msgid "Could not retrieve this program list. VRT Search API url is too long. Unfollowing some favorite programs will reduce url length and may fix this problem."
+msgid "Could not retrieve this program list. VRT Search API url is too long. Go to [B]VRT NU settings » Interface » Manage My favorites…[/B] and unfollow older favorite programs to fix this problem."
 msgstr ""
 
 msgctxt "#30975"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -496,7 +496,7 @@ msgstr "Info"
 
 msgctxt "#30432"
 msgid "Verbose"
-msgstr "Meer"
+msgstr "Uitgebreid"
 
 msgctxt "#30433"
 msgid "Debug"
@@ -915,8 +915,8 @@ msgid "Using a SOCKS proxy requires the PySocks library (script.module.pysocks) 
 msgstr "Het gebruik van SOCKS proxies vereist dat de PySocks library (script.module.pysocks) geïnstalleerd is."
 
 msgctxt "#30967"
-msgid "Could not retrieve this program list. VRT Search API url is too long. Unfollowing some favorite programs will reduce url length and may fix this problem."
-msgstr "Deze programmalijst kan niet opgehaald worden. VRT Search API url is te lang. Enkele favoriete programma's vergeten zal de lengte van de URL verminderen en dit probleem mogelijk oplossen."
+msgid "Could not retrieve this program list. VRT Search API url is too long. Go to [B]VRT NU settings » Interface » Manage My favorites…[/B] and unfollow older favorite programs to fix this problem."
+msgstr "Deze programmalijst kan niet opgehaald worden. VRT Search API url is te lang. Ga naar [B]VRT NU instellingen » Interface » Beheer Mijn favorieten[/B] en verwijder een aantal favoriete programma's om dit probleem op te lossen. "
 
 msgctxt "#30975"
 msgid "Failed to get user token from VRT NU"

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -1041,14 +1041,19 @@ def get_url_json(url, cache=None, headers=None, data=None, fail=None):
             url_length = len(req.selector)
         else:  # Python 2.7
             url_length = len(req.get_selector())
+        if exc.code == 400 and 7600 <= url_length <= 8192:
+            ok_dialog(heading='HTTP Error 400', message=localize(30967))
+            log_error('HTTP Error 400: Probably exceeded maximum url length: '
+                      'VRT Search API url has a length of {length} characters.', length=url_length)
+            return fail
         if exc.code == 413 and url_length > 8192:
             ok_dialog(heading='HTTP Error 413', message=localize(30967))
             log_error('HTTP Error 413: Exceeded maximum url length: '
                       'VRT Search API url has a length of {length} characters.', length=url_length)
             return fail
-        if exc.code == 400 and 7600 <= url_length <= 8192:
-            ok_dialog(heading='HTTP Error 400', message=localize(30967))
-            log_error('HTTP Error 400: Probably exceeded maximum url length: '
+        if exc.code == 431:
+            ok_dialog(heading='HTTP Error 431', message=localize(30967))
+            log_error('HTTP Error 431: Request header fields too large: '
                       'VRT Search API url has a length of {length} characters.', length=url_length)
             return fail
         json_data = get_json_data(exc, fail=fail)


### PR DESCRIPTION
This adds support for another HTTP error 431.

Also includes a small translation fix.

This fixes #725 