### PR TITLE
Check for unused translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ check-translations:
 	@-$(foreach lang,$(languages), \
 		msgcmp resources/language/resource.language.$(lang)/strings.po resources/language/resource.language.en_gb/strings.po; \
 	)
+	@tests/check-for-unused-translations.py
 
 check-addon: clean
 	@echo -e "$(white)=$(blue) Starting sanity addon tests$(reset)"

--- a/tests/check-for-unused-translations.py
+++ b/tests/check-for-unused-translations.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+""" Quick and dirty way to check if all translations might be used. """
+# -*- coding: utf-8 -*-
+
+import subprocess
+
+import polib
+
+error = 0
+
+# Load all python code from git
+code = subprocess.check_output(['git', 'grep', '', '--', 'resources/*.py', 'resources/settings.xml']).decode('utf-8')
+
+# Load po file
+po = polib.pofile('resources/language/resource.language.en_gb/strings.po')
+for entry in po:
+    # Extract msgctxt
+    msgctxt = entry.msgctxt.lstrip('#')
+
+    if msgctxt not in code:
+        print('No usage found for translation:')
+        print(entry)
+        error = 1
+
+exit(error)


### PR DESCRIPTION
I was just playing around with some things that we could check:

Current `master` branch has these unused translations:
```
No usage found for translation:
msgctxt "#30409"
msgid "episode"
msgstr ""

No usage found for translation:
msgctxt "#30957"
msgid ""
"Please increase the maximum bandwidth. Maximum bandwidth is set to {max} "
"kbps, but this stream needs a minimum of {min} kbps."
msgstr ""
```