### PR TITLE
Support new inputstream Python api in Kodi 19

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -265,10 +265,13 @@ def play(stream, video=None):
     play_item.setProperty('inputstream.adaptive.max_bandwidth', str(get_max_bandwidth() * 1000))
     play_item.setProperty('network.bandwidth', str(get_max_bandwidth() * 1000))
     if stream.stream_url is not None and stream.use_inputstream_adaptive:
-        play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
+        if kodi_version_major() < 19:
+            play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
+        else:
+            play_item.setProperty('inputstream', 'inputstream.adaptive')
         play_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
-        play_item.setMimeType('application/dash+xml')
         play_item.setContentLookup(False)
+        play_item.setMimeType('application/dash+xml')
         if stream.license_key is not None:
             import inputstreamhelper
             is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')


### PR DESCRIPTION
By the end of May,  both `inputstreamaddon` and `inputstreamclass` will be deprecated in the Kodi 19 nightly builds: https://forum.kodi.tv/showthread.php?tid=353560

This PR adds the new `inputstream` Python api for Kodi 19. For now, this is only needed for testing the add-on in Kodi 19.