### PR TITLE
Automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+on:
+  push:
+    tags:
+    - 'v*'
+jobs:
+  build:
+    name: Release plugin.video.vrt.nu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build zip files
+        run: |
+          sudo apt-get install libxml2-utils
+          make multizip release=1
+      - name: Get Krypton filename
+        id: get-krypton-filename
+        run: |
+          echo ::set-output name=krypton-filename::$(cd ..;ls plugin.video.vrt.nu*.zip | grep -v '+matrix.' | head -1)
+      - name: Get Matrix filename
+        id: get-matrix-filename
+        run: |
+          echo ::set-output name=matrix-filename::$(cd ..;ls plugin.video.vrt.nu*+matrix.*.zip | head -1)
+      - name: Get body
+        id: get-body
+        run: |
+          description=$(sed '1,/^## Releases$/d;/## v[0-9\.]* ([0-9-]*)/d;/^$/,$d' README.md)
+          echo $description
+          description="${description//'%'/'%25'}"
+          description="${description//$'\n'/'%0A'}"
+          description="${description//$'\r'/'%0D'}" 
+          echo ::set-output name=body::$description
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{ steps.get-body.outputs.body }}
+          draft: false
+          prerelease: false
+      - name: Upload Krypton/Leia zip
+        id: upload-krypton-zip 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: ${{ steps.get-krypton-filename.outputs.krypton-filename }}
+          asset_path: ../${{ steps.get-krypton-filename.outputs.krypton-filename }}
+          asset_content_type: application/zip
+      - name: Upload Matrix zip
+        id: upload-matrix-zip 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: ${{ steps.get-matrix-filename.outputs.matrix-filename }}
+          asset_path: ../${{ steps.get-matrix-filename.outputs.matrix-filename }}
+          asset_content_type: application/zip
+      - name: Generate distribution zip and submit to official kodi repository
+        id: kodi-addon-submitter
+        uses: xbmc/action-kodi-addon-submitter@v1.2
+        with:
+          kodi-repository: repo-plugins
+          kodi-version: krypton
+          addon-id: plugin.video.vrt.nu
+          kodi-matrix: true
+        env:
+          GH_USERNAME: ${{ github.actor }}
+          GH_TOKEN: ${{secrets.GH_TOKEN}}
+          EMAIL: ${{secrets.EMAIL}}

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
 export PYTHONPATH := $(CURDIR)/resources/lib:$(CURDIR)/tests
 PYTHON := python
+KODI_PYTHON_ABIS := 3.0.0 2.25.0
 
 name = $(shell xmllint --xpath 'string(/addon/@id)' addon.xml)
 version = $(shell xmllint --xpath 'string(/addon/@version)' addon.xml)
 git_branch = $(shell git rev-parse --abbrev-ref HEAD)
 git_hash = $(shell git rev-parse --short HEAD)
+matrix = $(findstring $(shell xmllint --xpath 'string(/addon/requires/import[@addon="xbmc.python"]/@version)' addon.xml), $(word 1,$(KODI_PYTHON_ABIS)))
 
-zip_name = $(name)-$(version)-$(git_branch)-$(git_hash).zip
+ifdef release
+	zip_name = $(name)-$(version).zip
+else
+	zip_name = $(name)-$(version)-$(git_branch)-$(git_hash).zip
+endif
+
 include_files = addon.xml LICENSE README.md resources/
 include_paths = $(patsubst %,$(name)/%,$(include_files))
 exclude_files = \*.new \*.orig \*.pyc \*.pyo
@@ -74,6 +81,15 @@ build: clean
 	@rm -f ../$(zip_name)
 	cd ..; zip -r $(zip_name) $(include_paths) -x $(exclude_files)
 	@echo -e "$(white)=$(blue) Successfully wrote package as: $(white)../$(zip_name)$(reset)"
+
+multizip: clean
+	@-$(foreach abi,$(KODI_PYTHON_ABIS), \
+		echo "cd /addon/requires/import[@addon='xbmc.python']/@version\nset $(abi)\nsave\nbye" | xmllint --shell addon.xml; \
+		matrix=$(findstring $(abi), $(word 1,$(KODI_PYTHON_ABIS))); \
+		if [ $$matrix ]; then version=$(version)+matrix.1; else version=$(version); fi; \
+		echo "cd /addon/@version\nset $$version\nsave\nbye" | xmllint --shell addon.xml; \
+		make build; \
+	)
 
 clean:
 	@echo -e "$(white)=$(blue) Cleaning up$(reset)"


### PR DESCRIPTION
This automates a Github and Kodi repo release when pushing a tag matching the pattern v*:

For instance:
```
git tag v2.3.3
git push upstream v2.3.3
```
This pull request includes the following functionality:
- Creates a GitHub release with zip packages for Krypton/Leia and Matrix and adds the latest changelog from README.md as the body text.
- Submits pull requests to `xbmc/repo-plugins` for  Krypton/Leia and Matrix 

For this to work, you obviously need to create a release commit first where the addon version and news tag in `addon.xml `and the changelog in `README.md` is updated.

Furthermore two secrets need to be configured in https://github.com/add-ons/plugin.video.vrt.nu/settings/secrets

- **GH_TOKEN** A secret that contains a github token with at least a `public_repo`  OAuth scope. You can generate a github token at https://github.com/settings/tokens/new
- **EMAIL** A secret containing the email address for submitting the pull requests to `xbmc/repo-plugins`.