### PR TITLE
Always select HLS-stream for vualto_radio1

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -640,8 +640,10 @@ def has_inputstream_adaptive():
 
 
 def has_addon(name):
-    """Checks if add-on is installed"""
-    return xbmc.getCondVisibility('System.HasAddon(%s)' % name) == 1
+    """Checks if add-on is installed and enabled"""
+    if kodi_version_major() < 19:
+        return xbmc.getCondVisibility('System.HasAddon(%s)' % name) == 1
+    return xbmc.getCondVisibility('System.AddonIsEnabled(%s)' % name) == 1
 
 
 def has_credentials():

--- a/resources/lib/streamservice.py
+++ b/resources/lib/streamservice.py
@@ -212,6 +212,11 @@ class StreamService:
             else:
                 protocol = 'hls'
 
+            # Workaround for Radio 1 live stream slow starts with HTTP 415
+            # https://github.com/add-ons/plugin.video.vrt.nu/issues/735
+            if video.get('video_id') == 'vualto_radio1':
+                protocol = 'hls'
+
             # Get stream manifest url
             manifest_url = next(stream.get('url') for stream in stream_json.get('targetUrls') if stream.get('type') == protocol)
 


### PR DESCRIPTION
This is a workaround for https://github.com/add-ons/plugin.video.vrt.nu/issues/735