### PR TITLE
Use GH_USERNAME secret for automatic submission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,6 @@ jobs:
           addon-id: plugin.video.vrt.nu
           kodi-matrix: true
         env:
-          GH_USERNAME: ${{ github.actor }}
+          GH_USERNAME: ${{secrets.GH_USERNAME}}
           GH_TOKEN: ${{secrets.GH_TOKEN}}
           EMAIL: ${{secrets.EMAIL}}


### PR DESCRIPTION
This should fix automatic creation of pull requests in `xbmc/repo-plugins` when tagging a new release: https://github.com/add-ons/plugin.video.vrt.nu/pull/733#issuecomment-622547001