### PR TITLE
Add query string to URI in log_access

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -316,5 +316,5 @@ def play_by_air_date(channel, start_date, end_date=None):
 
 def run(argv):
     """Addon entry point from wrapper"""
-    log_access(argv[0])
+    log_access(argv)
     plugin.run(argv)

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -873,10 +873,9 @@ def log(level=1, message='', **kwargs):
     xbmc.log(from_unicode(message), level % 3 if debug_logging else 2)
 
 
-def log_access(url, query_string=None):
+def log_access(argv):
     """Log addon access"""
-    message = 'Access: %s' % (url + ('?' + query_string if query_string else ''))
-    log(1, message)
+    log(1, 'Access: {url}{qs}', url=argv[0], qs=argv[2] if len(argv) > 2 else '')
 
 
 def log_error(message, **kwargs):


### PR DESCRIPTION
This was always intended, but missing from the implementation. The
log_access() interface changes with this