### PR TITLE
Add channel presets for IPTV Manager

### DIFF
--- a/resources/lib/data.py
+++ b/resources/lib/data.py
@@ -48,6 +48,7 @@ CHANNELS = [
         ],
         has_tvguide=True,
         epg_logo='https://images.vrt.be/orig/logo/een/een_LOGO_zwart.png',
+        epg_preset=1,
     ),
     dict(
         id='1H',
@@ -63,6 +64,7 @@ CHANNELS = [
         ],
         has_tvguide=True,
         epg_logo='https://images.vrt.be/orig/logo/canvas/CANVAS_logo_lichtblauw.jpg',
+        epg_preset=2,
     ),
     dict(
         id='O9',
@@ -78,6 +80,7 @@ CHANNELS = [
         ],
         has_tvguide=True,
         epg_logo='https://images.vrt.be/orig/logo/ketnet/ketnet_LOGO_rood_geel.png',
+        epg_preset=12,
     ),
     dict(
         id='',
@@ -89,6 +92,7 @@ CHANNELS = [
             dict(label='Ketnet Junior', url='https://www.youtube.com/channel/UCTxm_H52WlKWBEB_h7PjzFA'),
         ],
         epg_logo='https://images.vrt.be/orig/2019/07/19/c309360a-aa10-11e9-abcc-02b7b76bf47f.png',
+        epg_preset=11,
     ),
     dict(
         id='12',
@@ -100,6 +104,7 @@ CHANNELS = [
             dict(label='Sporza', url='https://www.youtube.com/user/SporzaOfficial'),
         ],
         epg_logo='https://images.vrt.be/orig/logo/sporza/sporza_logo_zwart.png',
+        epg_preset=801,
     ),
     dict(
         id='13',
@@ -113,6 +118,7 @@ CHANNELS = [
             dict(label='Terzake', url='https://www.youtube.com/user/terzaketv'),
         ],
         epg_logo='https://images.vrt.be/orig/logos/vrtnws.png',
+        epg_preset=802,
     ),
     dict(
         id='11',
@@ -125,6 +131,7 @@ CHANNELS = [
             dict(label='Universiteit van Vlaanderen', url='https://www.youtube.com/channel/UC7WpOKbKfzOOnD0PyUN_SYg'),
         ],
         epg_logo='https://images.vrt.be/orig/logos/radio1.png',
+        epg_preset=901,
     ),
     dict(
         id='24',
@@ -137,6 +144,7 @@ CHANNELS = [
             dict(label='Aha!', url='https://www.youtube.com/channel/UCa9lGLvXB-xJg3d0BjK_tIQ'),
         ],
         epg_logo='https://images.vrt.be/orig/logos/radio2.png',
+        epg_preset=902,
     ),
     dict(
         id='31',
@@ -149,6 +157,7 @@ CHANNELS = [
             dict(label='Iedereen klassiek', url='https://www.youtube.com/channel/UCgyfqQgt5_K8_zrxHgh_J2w'),
         ],
         epg_logo='https://images.vrt.be/orig/logos/klara.png',
+        epg_preset=903,
     ),
     dict(
         id='41',
@@ -161,6 +170,7 @@ CHANNELS = [
             dict(label='Studio Brussel', url='https://www.youtube.com/user/StuBru'),
         ],
         epg_logo='https://images.vrt.be/orig/2019/03/12/1e383cf5-44a7-11e9-abcc-02b7b76bf47f.png',
+        epg_preset=904,
     ),
     dict(
         id='55',
@@ -173,6 +183,7 @@ CHANNELS = [
             dict(label='MNM', url='https://www.youtube.com/user/MNMbe'),
         ],
         epg_logo='https://images.vrt.be/orig/logo/mnm/logo_witte_achtergrond.png',
+        epg_preset=905,
     ),
     dict(
         id='',
@@ -199,6 +210,7 @@ CHANNELS = [
         studio='VRT',
         live_stream_id='vualto_events1_geo',
         epg_logo='https://images.vrt.be/orig/logo/vrt.png',
+        epg_preset=851,
     ),
     dict(
         id='',
@@ -207,6 +219,7 @@ CHANNELS = [
         studio='VRT',
         live_stream_id='vualto_events2_geo',
         epg_logo='https://images.vrt.be/orig/logo/vrt.png',
+        epg_preset=852,
     ),
     dict(
         id='',
@@ -215,6 +228,7 @@ CHANNELS = [
         studio='VRT',
         live_stream_id='vualto_events3_geo',
         epg_logo='https://images.vrt.be/orig/logo/vrt.png',
+        epg_preset=853,
     ),
 ]
 

--- a/resources/lib/iptvmanager.py
+++ b/resources/lib/iptvmanager.py
@@ -43,6 +43,7 @@ class IPTVManager:
                 id='{name}.be'.format(**channel),
                 name=channel.get('label'),
                 logo=channel.get('epg_logo'),
+                preset=channel.get('epg_preset'),
                 stream='plugin://plugin.video.vrt.nu/play/id/{live_stream_id}'.format(**channel),
             ))
         return dict(version=1, streams=streams)


### PR DESCRIPTION
It is more convenient for our users if the more popular channels are
listed on top, regardless of the network. And if we can we should follow
known conventions.
 
| Channel       | Pref |Telenet | Belgacom
|--------------|------|----------|------------------
| Eén              | 1 | 2 | 1
| Canvas        | 2 | 4 | 2
| vtm             | 3 | 1 | 3
| Vier              | 4 | 3 | 4
| Vijf               | 5 | 6 | 5
| Zes              | 6 | 14 | 16
| Q2               | 7 | 5 | 6
| CAZ            | 8  | 9 | 8
| CAZ2          | 9  | ? | 18
| Vitaya         | 10 | 7 | 7
| Ketnet Jr    | 11 | N/A | N/A
| Ketnet        | 12 | 12 | 12
| VTM Kids   | 13 | 34 | 33
| BVN           | ? | N/A | N/A
| XITE           | ? | 44 | N/A
| Radio 1       | 901 | 900 | 800
| Radio 2 A    | 902 | 914 | 801
| Radio 2 L    | 902 | 915 | 802
| Radio 2 OV | 902 | 916 | 803
| Radio 2 VB  | 902 | 901 | 804
| Radio 2 WV | 902 | 917 | 805
| Klara           | 903 | 904 | 809
| StuBru        | 904 | 903 | 806
| MNM         | 905 | 902 | 807
| Qmusic       | ? | 910 | 820

Problem is that the known cable providers have different (sometimes useless- conventions.
- [Telenet](https://www2.telenet.be/content/dam/www-telenet-be/Corporate/referentieaanbod/Zenderkaart.pdf) *-- verouderd*
- [Telenet Brussel](https://www2.telenet.be/content/dam/www-telenet-be/TB/Producten/Televisie/downloads/Zenderkaarten/Vlaanderen_2017_v02.pdf) *-- 2017*
- [Proximus](https://www.proximus.be/dam/jcr:810fbecd-d01e-4c11-836e-73cdae9ef3ca/cdn/sites/support/en/pdf/tv-channels-flanders-nl~2020-04-02-16-06-07~cache.pdf) *-- 2020*