### PR TITLE
Assorted fixes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,7 +4,6 @@ disable=
     duplicate-code,  # Integration tests tend to test similar things
     fixme,  # Allow FIXMEs in code is a useful practice
     import-outside-toplevel,  # Done on purpose to reduce overhead at startup
-    line-too-long,  # Flake8 is used for testing line-length
     old-style-class,
     too-few-public-methods,
     too-many-arguments,
@@ -16,3 +15,4 @@ disable=
     too-many-public-methods,
     too-many-return-statements,
     too-many-statements,
+max-line-length=160

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -721,7 +721,7 @@ msgid "Integration with other Kodi add-ons"
 msgstr ""
 
 msgctxt "#30863"
-msgid "Install YouTube add-on"
+msgid "Install YouTube add-on…"
 msgstr ""
 
 msgctxt "#30864"
@@ -737,7 +737,7 @@ msgid "YouTube settings…"
 msgstr ""
 
 msgctxt "#30869"
-msgid "Install Up Next add-on"
+msgid "Install Up Next add-on…"
 msgstr ""
 
 msgctxt "#30870"
@@ -757,7 +757,7 @@ msgid "Open Up Next service add-on settings."
 msgstr ""
 
 msgctxt "#30875"
-msgid "Install IPTV Manager add-on"
+msgid "Install IPTV Manager add-on…"
 msgstr ""
 
 msgctxt "#30877"
@@ -765,11 +765,11 @@ msgid "Enable IPTV Manager integration"
 msgstr ""
 
 msgctxt "#30879"
-msgid "Open IPTV Manager service add-on settings."
+msgid "IPTV Manager settings…"
 msgstr ""
 
 msgctxt "#30881"
-msgid "Install PySocks library"
+msgid "Install PySocks library…"
 msgstr ""
 
 msgctxt "#30900"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -721,8 +721,8 @@ msgid "Integration with other Kodi add-ons"
 msgstr "Integratie met andere Kodi add-ons"
 
 msgctxt "#30863"
-msgid "Install YouTube add-on"
-msgstr "Installeer de YouTube add-on"
+msgid "Install YouTube add-on…"
+msgstr "Installeer de YouTube add-on…"
 
 msgctxt "#30864"
 msgid "Show YouTube channel content in the Channels menu."
@@ -737,8 +737,8 @@ msgid "YouTube settings…"
 msgstr "YouTube instellingen…"
 
 msgctxt "#30869"
-msgid "Install Up Next add-on"
-msgstr "Installeer de Up Next add-on"
+msgid "Install Up Next add-on…"
+msgstr "Installeer de Up Next add-on…"
 
 msgctxt "#30870"
 msgid "This enables a Netflix style pop up notification for watching the next episode using the Up Next service add-on."
@@ -757,20 +757,20 @@ msgid "Open Up Next service add-on settings."
 msgstr "Open de Up Next service add-on instellingen."
 
 msgctxt "#30875"
-msgid "Install IPTV Manager add-on"
-msgstr "Installeer de IPTV Manager add-on"
+msgid "Install IPTV Manager add-on…"
+msgstr "Installeer de IPTV Manager add-on…"
 
 msgctxt "#30877"
 msgid "Enable IPTV Manager integration"
 msgstr "Activeer IPTV Manager integratie"
 
 msgctxt "#30879"
-msgid "Open IPTV Manager service add-on settings."
-msgstr ""
+msgid "IPTV Manager settings…"
+msgstr "IPTV Manager instellingen…"
 
 msgctxt "#30881"
-msgid "Install PySocks library"
-msgstr "Installeer de PySocks library"
+msgid "Install PySocks library…"
+msgstr "Installeer de PySocks library…"
 
 msgctxt "#30900"
 msgid "Expert"

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -87,32 +87,32 @@ class SafeDict(dict):
 
 
 def addon_icon():
-    """Cache and return add-on icon"""
+    """Return add-on icon"""
     return get_addon_info('icon')
 
 
 def addon_id():
-    """Cache and return add-on ID"""
+    """Return add-on ID"""
     return get_addon_info('id')
 
 
 def addon_fanart():
-    """Cache and return add-on fanart"""
+    """Return add-on fanart"""
     return get_addon_info('fanart')
 
 
 def addon_name():
-    """Cache and return add-on name"""
+    """Return add-on name"""
     return get_addon_info('name')
 
 
 def addon_path():
-    """Cache and return add-on path"""
+    """Return add-on path"""
     return get_addon_info('path')
 
 
 def addon_profile():
-    """Cache and return add-on profile"""
+    """Return add-on profile"""
     return to_unicode(xbmc.translatePath(ADDON.getAddonInfo('profile')))
 
 
@@ -358,9 +358,17 @@ def localize(string_id, **kwargs):
 
 
 def localize_time(time):
-    """Return localized time"""
-    time_format = xbmc.getRegion('time').replace(':%S', '')  # Strip off seconds
-    return time.strftime(time_format).lstrip('0')  # Remove leading zero on all platforms
+    """Localize time format"""
+    time_format = xbmc.getRegion('time')
+
+    # Fix a bug in Kodi v18.5 and older causing double hours
+    # https://github.com/xbmc/xbmc/pull/17380
+    time_format = time_format.replace('%H%H:', '%H:')
+
+    # Strip off seconds
+    time_format = time_format.replace(':%S', '')
+
+    return time.strftime(time_format)
 
 
 def localize_date(date, strftime):

--- a/tests/test_kodiutils.py
+++ b/tests/test_kodiutils.py
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """Unit tests for Kodi utilities"""
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,line-too-long
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 import unittest

--- a/tests/test_resumepoints.py
+++ b/tests/test_resumepoints.py
@@ -43,7 +43,15 @@ class TestResumePoints(unittest.TestCase):
         """Test items, sort and order"""
 
         # Ensure a continue episode exists (Winteruur met Lize Feryn (beschikbaar tot 26 maart 2025))
-        self._resumepoints.update(asset_id='contentdamvrt20191015winteruurr005a0001depotwp00162177', title='Winteruur', url='/vrtnu/a-z/winteruur/5/winteruur-s5a1/', watch_later=True, position=38, total=635, whatson_id='705308178527')
+        self._resumepoints.update(
+            asset_id='contentdamvrt20191015winteruurr005a0001depotwp00162177',
+            title='Winteruur',
+            url='/vrtnu/a-z/winteruur/5/winteruur-s5a1/',
+            watch_later=True,
+            position=38,
+            total=635,
+            whatson_id='705308178527',
+        )
 
         episode_items, sort, ascending, content = self._apihelper.list_episodes(page=1, variety='continue')
         self.assertTrue(episode_items)
@@ -80,7 +88,15 @@ class TestResumePoints(unittest.TestCase):
         print('%s = %s' % (asset_id, first_entry))
 
         # Remove Winteruur met Lize Feryn (beschikbaar tot 26 maart 2025)
-        self._resumepoints.update(asset_id='contentdamvrt20191015winteruurr005a0001depotwp00162177', title='Winteruur', url='/vrtnu/a-z/winteruur/5/winteruur-s5a1/', watch_later=False, position=635, total=635, whatson_id='705308178527')
+        self._resumepoints.update(
+            asset_id='contentdamvrt20191015winteruurr005a0001depotwp00162177',
+            title='Winteruur',
+            url='/vrtnu/a-z/winteruur/5/winteruur-s5a1/',
+            watch_later=False,
+            position=635,
+            total=635,
+            whatson_id='705308178527',
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """Integration tests for Routing functionality"""
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,line-too-long
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 from datetime import datetime, timedelta

--- a/tests/xbmcgui.py
+++ b/tests/xbmcgui.py
@@ -191,65 +191,75 @@ class ListItem:
         self.label = kodi_to_ansi(label)
         self.label2 = kodi_to_ansi(label2)
         self.path = path
+        self.offscreen = offscreen
 
-    @staticmethod
-    def addContextMenuItems(items, replaceItems=False):
+        self.art = dict()
+        self.content_lookup = None
+        self.context_menu = list()
+        self.info = dict()
+        self.info_type = None
+        self.is_folder = False
+        self.mimetype = None
+        self.properties = dict()
+        self.rating = None
+        self.stream_info = dict()
+        self.stream_type = None
+        self.subtitles = list()
+        self.unique_ids = list()
+
+    def addContextMenuItems(self, items, replaceItems=False):
         """A stub implementation for the xbmcgui ListItem class addContextMenuItems() method"""
-        return
+        if replaceItems:
+            self.context_menu = items
+        else:
+            self.context_menu.append(items)
 
-    @staticmethod
-    def addStreamInfo(stream_type, stream_values):
+    def addStreamInfo(self, stream_type, stream_values):
         """A stub implementation for the xbmcgui LitItem class addStreamInfo() method"""
-        return
+        self.stream_type = stream_type
+        self.stream_info = stream_values
 
-    @staticmethod
-    def setArt(key):
+    def setArt(self, key):
         """A stub implementation for the xbmcgui ListItem class setArt() method"""
-        return
+        self.art = key
 
-    @staticmethod
-    def setContentLookup(enable):
+    def setContentLookup(self, enable):
         """A stub implementation for the xbmcgui ListItem class setContentLookup() method"""
-        return
+        self.content_lookup = enable
 
-    @staticmethod
-    def setInfo(type, infoLabels):  # pylint: disable=redefined-builtin
+    def setInfo(self, type, infoLabels):  # pylint: disable=redefined-builtin
         """A stub implementation for the xbmcgui ListItem class setInfo() method"""
-        return
+        self.info_type = type
+        self.info = infoLabels
 
-    @staticmethod
-    def setIsFolder(isFolder):
+    def setIsFolder(self, isFolder):
         """A stub implementation for the xbmcgui ListItem class setIsFolder() method"""
-        return
+        self.is_folder = isFolder
 
-    @staticmethod
-    def setMimeType(mimetype):
+    def setMimeType(self, mimetype):
         """A stub implementation for the xbmcgui ListItem class setMimeType() method"""
-        return
+        self.mimetype = mimetype
 
     def setPath(self, path):
         """A stub implementation for the xbmcgui ListItem class setPath() method"""
         self.path = path
 
-    @staticmethod
-    def setProperty(key, value):
+    def setProperty(self, key, value):
         """A stub implementation for the xbmcgui ListItem class setProperty() method"""
-        return
+        self.properties[key] = value
 
-    @staticmethod
-    def setProperties(dictionary):
+    def setProperties(self, dictionary):
         """A stub implementation for the xbmcgui ListItem class setProperties() method"""
-        return
+        self.properties.update(dictionary)
 
-    @staticmethod
-    def setSubtitles(subtitleFiles):
+    def setSubtitles(self, subtitleFiles):
         """A stub implementation for the xbmcgui ListItem class setSubtitles() method"""
-        return
+        self.subtitles = subtitleFiles
 
-    @staticmethod
-    def setUniqueIDs(values, defaultrating=None):
+    def setUniqueIDs(self, values, defaultrating=None):
         """A stub implementation for the xbmcgui ListItem class setUniqueIDs() method"""
-        return
+        self.unique_ids = values
+        self.rating = defaultrating
 
 
 class Window:

--- a/tests/xbmcplugin.py
+++ b/tests/xbmcplugin.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from xbmc import LOGFATAL, LOGINFO, log
+from xbmcaddon import Addon
 from xbmcextra import kodi_to_ansi, uri_to_path
 
 try:  # Python 3
@@ -88,6 +89,11 @@ def endOfDirectory(handle, succeeded=True, updateListing=True, cacheToDisc=True)
     # print(kodi_to_ansi('[B]-=( [COLOR=cyan]--------[/COLOR] )=-[/B]'))
 
 
+def getSetting(handle, key):
+    """A stub implementation of the xbmcplugin getSetting() function"""
+    return Addon().getSetting(key)
+
+
 def setContent(handle, content):
     """A stub implementation of the xbmcplugin setContent() function"""
 
@@ -103,6 +109,12 @@ def setPluginCategory(handle, category):
 
 def setResolvedUrl(handle, succeeded, listitem):
     """A stub implementation of the xbmcplugin setResolvedUrl() function"""
+
+    print(kodi_to_ansi('[B][COLOR=yellow]Title[/COLOR]: {label}[/B]'.format(label=listitem.label)))
+    print(kodi_to_ansi('[COLOR=yellow]URL[/COLOR]:\n{url}'.format(url=listitem.path)))
+    if listitem.info.get('plot'):
+        print(kodi_to_ansi('[COLOR=yellow]Plot[/COLOR]:\n{plot}'.format(**listitem.info)))
+
     request = Request(listitem.path)
     request.get_method = lambda: 'HEAD'
     try:


### PR DESCRIPTION
This PR includes:
- Enable line-length checking in pylint (line-too-long)
- Fix IPTV Manager menu item
- Make clear installing add-ons for integration opens a new window
- Fix a bug in localize_time()
- Add getSetting() to xbmcplugin (backport from plugin.video.fosdem)
- Make ListItem() stub save data and show it when running setResolvedUrl()

*(A list of unrelated non-critical fixes I collected over the last week)*