### PR TITLE
Mark IPTV Manager support as experimental

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -761,7 +761,7 @@ msgid "Install IPTV Manager add-on"
 msgstr ""
 
 msgctxt "#30877"
-msgid "Enable IPTV Manager integration"
+msgid "Enable IPTV Manager integration (experimental)"
 msgstr ""
 
 msgctxt "#30879"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -761,8 +761,8 @@ msgid "Install IPTV Manager add-on"
 msgstr "Installeer de IPTV Manager add-on"
 
 msgctxt "#30877"
-msgid "Enable IPTV Manager integration"
-msgstr "Activeer IPTV Manager integratie"
+msgid "Enable IPTV Manager integration (experimental)"
+msgstr "Activeer IPTV Manager integratie (experimenteel)"
 
 msgctxt "#30879"
 msgid "Open IPTV Manager service add-on settings."


### PR DESCRIPTION
This is just to make sure that it is clear it is not yet supported as-is.
Even though it works fine and has no impact on the proper working of the
add-on whatsoever.