### PR TITLE
Revert vualto_radio1 workaround

### DIFF
--- a/resources/lib/streamservice.py
+++ b/resources/lib/streamservice.py
@@ -212,11 +212,6 @@ class StreamService:
             else:
                 protocol = 'hls'
 
-            # Workaround for Radio 1 live stream slow starts with HTTP 415
-            # https://github.com/add-ons/plugin.video.vrt.nu/issues/735
-            if video.get('video_id') == 'vualto_radio1':
-                protocol = 'hls'
-
             # Get stream manifest url
             manifest_url = next(stream.get('url') for stream in stream_json.get('targetUrls') if stream.get('type') == protocol)
 


### PR DESCRIPTION
Now that we fixed InputStream Adaptive to handle this more gracefully,
and the subtitle track has disappeared from the manifest, we can revert
our workaround.

This resolves #735