### PR TITLE
Add a simple option for users to update VRT NU add-on

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -506,6 +506,14 @@ msgctxt "#30440"
 msgid "A-Z"
 msgstr ""
 
+msgctxt "#30450"
+msgid "Update add-on repositories"
+msgstr ""
+
+msgctxt "#30451"
+msgid "If a VRT NU add-on update is available, it will now be updated and you will be notified.\nMake sure the VRT NU add-on has [I]Auto-update[/I] enabled."
+msgstr ""
+
 
 ### SETTINGS
 msgctxt "#30700"
@@ -770,6 +778,18 @@ msgstr ""
 
 msgctxt "#30881"
 msgid "Install PySocks library…"
+msgstr ""
+
+msgctxt "#30890"
+msgid "Updates"
+msgstr ""
+
+msgctxt "#30891"
+msgid "Update the VRT NU add-on"
+msgstr ""
+
+msgctxt "#30892"
+msgid "Update Kodi repositories and install add-on updates…"
 msgstr ""
 
 msgctxt "#30900"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -511,7 +511,7 @@ msgid "Update add-on repositories"
 msgstr ""
 
 msgctxt "#30451"
-msgid "If a VRT NU add-on update is available, it will now be updated and you will be notified.\nMake sure the VRT NU add-on has [I]Auto-update[/I] enabled."
+msgid "If a VRT NU add-on update is available, it will now be updated and you will be notified.\nMake sure you have [I]Auto-update[/I] enabled in Kodi and the VRT NU add-on."
 msgstr ""
 
 

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -506,6 +506,14 @@ msgctxt "#30440"
 msgid "A-Z"
 msgstr "A-Z"
 
+msgctxt "#30450"
+msgid "Update add-on repositories"
+msgstr "Add-on repositories worden bijgewerkt"
+
+msgctxt "#30451"
+msgid "If a VRT NU add-on update is available, it will now be updated and you will be notified.\nMake sure the VRT NU add-on has [I]Auto-update[/I] enabled."
+msgstr "Als een VRT NU update beschikbaar is, zal deze nu worden geïnstalleerd en krijg je hiervan een melding.\nControleer wel dat [I]Automatische update[/I] is ingesteld voor de VRT NU add-on."
+
 
 ### SETTINGS
 msgctxt "#30700"
@@ -771,6 +779,18 @@ msgstr "IPTV Manager instellingen…"
 msgctxt "#30881"
 msgid "Install PySocks library…"
 msgstr "Installeer de PySocks library…"
+
+msgctxt "#30890"
+msgid "Updates"
+msgstr "Updates"
+
+msgctxt "#30891"
+msgid "Update the VRT NU add-on"
+msgstr "Bijwerken van de VRT NU add-on"
+
+msgctxt "#30892"
+msgid "Update Kodi repositories and install add-on updates…"
+msgstr "Werk de Kodi repositories bij en installeer nieuwe add-ons…"
 
 msgctxt "#30900"
 msgid "Expert"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -511,8 +511,8 @@ msgid "Update add-on repositories"
 msgstr "Add-on repositories worden bijgewerkt"
 
 msgctxt "#30451"
-msgid "If a VRT NU add-on update is available, it will now be updated and you will be notified.\nMake sure the VRT NU add-on has [I]Auto-update[/I] enabled."
-msgstr "Als een VRT NU update beschikbaar is, zal deze nu worden geïnstalleerd en krijg je hiervan een melding.\nControleer wel dat [I]Automatische update[/I] is ingesteld voor de VRT NU add-on."
+msgid "If a VRT NU add-on update is available, it will now be updated and you will be notified.\nMake sure you have [I]Auto-update[/I] enabled in Kodi and the VRT NU add-on."
+msgstr "Als een VRT NU update beschikbaar is, zal deze nu worden geïnstalleerd en krijg je hiervan een melding.\nControleer wel dat [I]Automatische update[/I] is ingesteld voor Kodi en de VRT NU add-on."
 
 
 ### SETTINGS

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -10,7 +10,7 @@ try:  # Python 3
 except ImportError:  # Python 2
     from urllib import unquote_plus
 
-from kodiutils import end_of_directory, localize, log_access, notification, refresh_caches
+from kodiutils import end_of_directory, execute_builtin, localize, log_access, notification, ok_dialog, refresh_caches
 from utils import from_unicode, to_unicode
 
 plugin = Plugin()  # pylint: disable=invalid-name
@@ -328,6 +328,13 @@ def iptv_epg():
     from iptvmanager import IPTVManager
     port = int(plugin.args.get('port')[0])
     IPTVManager(port).send_epg()
+
+
+@plugin.route('/update/repos')
+def update_repos():
+    """Force an update of the repositories"""
+    execute_builtin('UpdateAddonRepos')
+    ok_dialog(heading=localize(30450), message=localize(30451))
 
 
 def run(argv):

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -844,6 +844,11 @@ def container_reload(url=None):
     container_update(url)
 
 
+def execute_builtin(builtin):
+    """Run an internal Kodi builtin"""
+    xbmc.executebuiltin(builtin)
+
+
 def end_of_directory():
     """Close a virtual directory, required to avoid a waiting Kodi"""
     from addon import plugin

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -69,6 +69,10 @@
         <!-- PySocks -->
         <setting label="30881" help="30882" type="action" action="InstallAddon(script.module.pysocks)" option="close" visible="!System.HasAddon(script.module.pysocks)"/>
     </category>
+    <category label="30890"> <!-- Updates -->
+        <setting label="30891" type="lsep"/> <!-- Update the VRT NU add-on -->
+        <setting label="30892" help="30893" type="action" action="RunPlugin(plugin://plugin.video.vrt.nu/update/repos)" option="close"/>
+    </category>
     <category label="30900"> <!-- Expert -->
         <setting label="30901" type="lsep"/> <!-- InputStream Adaptive -->
         <setting label="30903" type="action" visible="!System.HasAddon(inputstream.adaptive)" enable="false"/>


### PR DESCRIPTION
This offers an easier path for users to check for updates or re-install
the VRT NU add-on.

This relates to #765