### PR TITLE
IPTV Manager improvements

### DIFF
--- a/resources/lib/iptvmanager.py
+++ b/resources/lib/iptvmanager.py
@@ -27,7 +27,7 @@ class IPTVManager:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(('127.0.0.1', self.port))
             try:
-                sock.send(json.dumps(func()))  # pylint: disable=not-callable
+                sock.send(json.dumps(func()).encode())  # pylint: disable=not-callable
             finally:
                 sock.close()
 

--- a/resources/lib/tvguide.py
+++ b/resources/lib/tvguide.py
@@ -218,12 +218,18 @@ class TVGuide:
                 if epg_id not in epg_data:
                     epg_data[epg_id] = []
                 for episode in episodes:
+                    if episode.get('url'):
+                        path = url_for('play_url', video_url=add_https_proto(episode.get('url')))
+                    else:
+                        path = None
                     epg_data[epg_id].append(dict(
                         start=episode.get('startTime'),
                         stop=episode.get('endTime'),
                         image=add_https_proto(episode.get('image', '')),
                         title=episode.get('title'),
+                        subtitle=episode.get('subtitle'),
                         description=html_to_kodi(episode.get('description', '')),
+                        stream=path,
                     ))
         return epg_data
 


### PR DESCRIPTION
This PR improves the IPTV Manager integration by exposing the `subtitle`, and the `stream` URL.

The `stream` url can be used in Kodi Matrix to improve the direct playing of a program from the EPG guide, without using the airdate-api.

I would have loved to also add the `episode` number and the `genre` field, but it seems that these fields aren't available in the API we are using now (https://www.vrt.be/bin/epg/schedule.2020-06-06.json).

This information is available on the services.vrt.be API, so maybe it would make sense to start using that source? 

See http://services.vrt.be/htmlview/?href=%2Fepg%2Fschedules%2Ftoday%3Fchannel_code%3DO8%26type%3Dday&rel=http%3A%2F%2Fservices.vrt.be%2Fepg%2Frel%2Fschedule%2Ftoday