### PR TITLE
Fix categories

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -209,7 +209,7 @@ msgid "Comedy"
 msgstr ""
 
 msgctxt "#30077"
-msgid "Children"
+msgid "Children and youth"
 msgstr ""
 
 msgctxt "#30078"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -248,6 +248,10 @@ msgctxt "#30086"
 msgid "Science and nature"
 msgstr ""
 
+msgctxt "#30087"
+msgid "Worldview"
+msgstr ""
+
 ### FEATURED
 msgctxt "#30100"
 msgid "Online exclusive"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -209,8 +209,8 @@ msgid "Comedy"
 msgstr "Humor"
 
 msgctxt "#30077"
-msgid "Children"
-msgstr "Kinderen"
+msgid "Children and youth"
+msgstr "Kinderen en jongeren"
 
 msgctxt "#30078"
 msgid "Cooking"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -248,6 +248,10 @@ msgctxt "#30086"
 msgid "Science and nature"
 msgstr "Wetenschap en natuur"
 
+msgctxt "#30087"
+msgid "Worldview"
+msgstr "Levensbeschouwing"
+
 ### FEATURED
 msgctxt "#30100"
 msgid "Online exclusive"

--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -13,7 +13,7 @@ except ImportError:  # Python 2
 
 from data import CHANNELS
 from helperobjects import TitleItem
-from kodiutils import (delete_cached_thumbnail, get_cached_url_json, get_global_setting,
+from kodiutils import (delete_cached_thumbnail, get_cache, get_cached_url_json, get_global_setting,
                        get_proxies, get_setting_bool, get_setting_int, get_url_json, has_addon, localize,
                        localize_from_data, log, ttl, url_for)
 from metadata import Metadata
@@ -751,8 +751,19 @@ class ApiHelper:
 
     def list_categories(self):
         """Construct a list of category ListItems"""
-        from webscraper import get_categories
+        from webscraper import get_categories, valid_categories
         categories = get_categories()
+
+        # Use the cache anyway (better than hard-coded)
+        if not valid_categories(categories):
+            categories = get_cache('categories.json', ttl=None)
+
+        # Fall back to internal hard-coded categories
+        if not valid_categories(categories):
+            from data import CATEGORIES
+            log(2, 'Fall back to internal hard-coded categories')
+            categories = CATEGORIES
+
         category_items = []
         from data import CATEGORIES
         for category in self.localize_categories(categories, CATEGORIES):

--- a/resources/lib/data.py
+++ b/resources/lib/data.py
@@ -19,6 +19,7 @@ CATEGORIES = [
     dict(name='Humor', id='humor', msgctxt=30076),
     dict(name='Kinderen', id='voor-kinderen', msgctxt=30077),
     dict(name='Koken', id='koken', msgctxt=30078),
+    dict(name='Levensbeschouwing', id='levensbeschouwing', msgctxt=30087),
     dict(name='Lifestyle', id='lifestyle', msgctxt=30079),
     dict(name='Muziek', id='muziek', msgctxt=30080),
     dict(name='Nieuws en actua', id='nieuws-en-actua', msgctxt=30081),

--- a/resources/lib/data.py
+++ b/resources/lib/data.py
@@ -17,7 +17,7 @@ CATEGORIES = [
     dict(name='Films', id='films', msgctxt=30074),
     dict(name='Human interest', id='human-interest', msgctxt=30075),
     dict(name='Humor', id='humor', msgctxt=30076),
-    dict(name='Kinderen', id='voor-kinderen', msgctxt=30077),
+    dict(name='Kinderen en jongeren', id='voor-kinderen', msgctxt=30077),
     dict(name='Koken', id='koken', msgctxt=30078),
     dict(name='Levensbeschouwing', id='levensbeschouwing', msgctxt=30087),
     dict(name='Lifestyle', id='lifestyle', msgctxt=30079),

--- a/resources/lib/webscraper.py
+++ b/resources/lib/webscraper.py
@@ -65,7 +65,7 @@ def get_category_title(element):
     """Return a category title, if available"""
     found_element = element.find('h3')
     if found_element:
-        return strip_newlines(found_element.contents[0])
+        return strip_newlines(found_element.a.contents[0])
     # FIXME: We should probably fall back to something sensible here, or raise an exception instead
     return ''
 

--- a/resources/lib/webscraper.py
+++ b/resources/lib/webscraper.py
@@ -50,14 +50,6 @@ def get_categories():
             from json import dumps
             update_cache('categories.json', dumps(categories))
 
-    # Use the cache anyway (better than hard-coded)
-    if not valid_categories(categories):
-        categories = get_cache(cache_file, ttl=None)
-
-    # Fall back to internal hard-coded categories if all else fails
-    if not valid_categories(categories):
-        from data import CATEGORIES
-        categories = CATEGORIES
     return categories
 
 

--- a/tests/test_vrtplayer.py
+++ b/tests/test_vrtplayer.py
@@ -98,7 +98,7 @@ class TestVRTPlayer(unittest.TestCase):
     def test_categories(self):
         """Test to ensure our hardcoded categories conforms to scraped categories"""
         category_items = self._apihelper.list_categories()
-        self.assertEqual(len(category_items), 17)
+        self.assertEqual(len(category_items), 18)
 
     def test_featured(self):
         """Test to ensure our hardcoded categories conforms to scraped categories"""


### PR DESCRIPTION
VRT NU added "Levensbeschouwing" category, changed html  and changed the name of the "Kinderen" category.
The status check didn't detect these changes because the fallback to hardcoded categories was wrongly placed inside the webscraper function.

This pull request fixes this and adds all new changes to the hardcoded categories.