### PR TITLE
Improve playing from TV guide

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -526,6 +526,9 @@ msgctxt "#30453"
 msgid "Kodi is configured to not update add-ons automatically, so you will not get VRT NU updates unless you fix this setting.\nWe will open de Kodi settings, please change this setting."
 msgstr ""
 
+msgctxt "#30454"
+msgid "from livestream cache"
+msgstr ""
 
 
 ### SETTINGS
@@ -662,7 +665,7 @@ msgid "Streaming and DRM"
 msgstr ""
 
 msgctxt "#30787"
-msgid "Use Widevine DRM [COLOR=gray]for protected content)[/COLOR]"
+msgid "Use Widevine DRM [COLOR=gray](for protected content)[/COLOR]"
 msgstr ""
 
 msgctxt "#30788"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -526,6 +526,10 @@ msgctxt "#30453"
 msgid "Kodi is configured to not update add-ons automatically, so you will not get VRT NU updates unless you fix this setting.\nWe will open de Kodi settings, please change this setting."
 msgstr "Kodi is ingesteld om add-ons niet automatisch bij te werken, dus je zal geen VRT NU updates ontvangen tenzij je deze instelling aanpast.\nWe openen nu de Kodi-instellingen zodat je dit kan wijzigen."
 
+msgctxt "#30454"
+msgid "from livestream cache"
+msgstr "uit de livestream-cache"
+
 
 ### SETTINGS
 msgctxt "#30700"

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -308,10 +308,17 @@ def play_upnext(video_id):
 
 @plugin.route('/play/airdate/<channel>/<start_date>')
 @plugin.route('/play/airdate/<channel>/<start_date>/<end_date>')
-def play_by_air_date(channel, start_date, end_date=None):
-    """The API interface to play an episode of a program given the channel and the air date in iso format (2019-07-06T19:35:00)"""
+def play_air_date(channel, start_date, end_date=None):
+    """The API interface to play an episode of a program given the channel, start (and end) timestamp(s) in ISO 8601 format (e.g. 2020-06-15T10:35:00)"""
     from vrtplayer import VRTPlayer
     VRTPlayer().play_episode_by_air_date(channel, start_date, end_date)
+
+
+@plugin.route('/play/whatson/<whatson_id>')
+def play_whatson_id(whatson_id):
+    """The API interface to play a video by using a whatson_id"""
+    from vrtplayer import VRTPlayer
+    VRTPlayer().play_episode_by_whatson_id(whatson_id=whatson_id)
 
 
 @plugin.route('/iptv/channels')

--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -444,14 +444,17 @@ class ApiHelper:
 
             # Offairdate defined
             if offairdate and now - timedelta(hours=24) <= offairdate <= now:
-                start_date = onairdate.astimezone(dateutil.tz.UTC).isoformat()[0:19]
-                end_date = offairdate.astimezone(dateutil.tz.UTC).isoformat()[0:19]
+                start_date = onairdate.astimezone(dateutil.tz.UTC).isoformat()[:19]
+                end_date = offairdate.astimezone(dateutil.tz.UTC).isoformat()[:19]
 
             if start_date and end_date:
+                info = self._metadata.get_info_labels(episode_guess, channel=channel, date=start_date)
+                live2vod_title = '{} ({})'.format(info.get('tvshowtitle'), localize(30454))  # from livestream cache
+                info.update(tvshowtitle=live2vod_title)
                 video_item = TitleItem(
                     label=self._metadata.get_label(episode_guess),
                     art_dict=self._metadata.get_art(episode_guess),
-                    info_dict=self._metadata.get_info_labels(episode_guess, channel=channel, date=start_date),
+                    info_dict=info,
                     prop_dict=self._metadata.get_properties(episode_guess),
                 )
                 video = dict(

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -739,27 +739,12 @@ class Metadata:
 
         # VRT NU Schedule API (some are missing vrt.whatson-id)
         elif api_data.get('vrt.whatson-id') or api_data.get('startTime'):
-            from datetime import datetime
-            import dateutil.parser
-            import dateutil.tz
             title = html_to_kodi(api_data.get('subtitle', '') or api_data.get('shortDescription', ''))
             label = '{start} - [B]{program}[/B]{title}'.format(
                 start=api_data.get('start'),
                 program=api_data.get('title'),
                 title=' - ' + title if title else '',
             )
-            now = datetime.now(dateutil.tz.tzlocal())
-            start_date = dateutil.parser.parse(api_data.get('startTime'))
-            end_date = dateutil.parser.parse(api_data.get('endTime'))
-            if api_data.get('url'):
-                if start_date <= now <= end_date:  # Now playing
-                    label = '[COLOR={highlighted}]%s[/COLOR] %s' % (label, localize(30301))
-            else:
-                # This is a non-actionable item
-                if start_date < now <= end_date:  # Now playing
-                    label = '[COLOR={greyedout}]%s[/COLOR] %s' % (label, localize(30301))
-                else:
-                    label = '[COLOR={greyedout}]%s[/COLOR]' % label
 
         # Not Found
         else:

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -342,6 +342,16 @@ class VRTPlayer:
             return
         self.play(video)
 
+    def play_episode_by_whatson_id(self, whatson_id):
+        """Play an episode of a program given the whatson_id"""
+        video = self._apihelper.get_single_episode(whatson_id=whatson_id)
+        if not video:
+            log_error('Play episode by whatson_id failed, whatson_id {whatson_id}', whatson_id=whatson_id)
+            ok_dialog(message=localize(30954))
+            end_of_directory()
+            return
+        self.play(video)
+
     def play_upnext(self, video_id):
         """Play the next episode of a program by video_id"""
         video = self._apihelper.get_single_episode(video_id=video_id)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -249,13 +249,13 @@ class TestRouting(unittest.TestCase):
         """Play episode by air date method: /play/airdate/<channel>/<start_date>"""
         # Test Het Journaal
         addon.run([lastweek.strftime('plugin://plugin.video.vrt.nu/play/airdate/een/%Y-%m-%dT19:00:00'), '0', ''])
-        self.assertEqual(plugin.url_for(addon.play_by_air_date,
+        self.assertEqual(plugin.url_for(addon.play_air_date,
                                         channel='een',
                                         start_date=lastweek.strftime('%Y-%m-%dT19:00:00')),
                          lastweek.strftime('plugin://plugin.video.vrt.nu/play/airdate/een/%Y-%m-%dT19:00:00'))
         # Test TerZake
         addon.run([lastweek.strftime('plugin://plugin.video.vrt.nu/play/airdate/canvas/%Y-%m-%dT20:00:00'), '0', ''])
-        self.assertEqual(plugin.url_for(addon.play_by_air_date,
+        self.assertEqual(plugin.url_for(addon.play_air_date,
                                         channel='canvas',
                                         start_date=lastweek.strftime('%Y-%m-%dT20:00:00')),
                          lastweek.strftime('plugin://plugin.video.vrt.nu/play/airdate/canvas/%Y-%m-%dT20:00:00'))


### PR DESCRIPTION
This includes improvements to play episodes from the VRT NU add-on TV guide and IPTV TV guide:
- play using whatson_id and add metadata to the play item (instead of VRT NU url webscraping)
- fallback to airdate 24-hour livestream cache if there is no VOD stream available
