### PR TITLE
Fix season items

### DIFF
--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -157,10 +157,9 @@ class ApiHelper:
         season_items = []
         sort = 'label'
         ascending = True
-        content = 'seasons'
+        content = 'files'
 
         episode = random.choice(episodes)
-        info_labels = self._metadata.get_info_labels(episode, season=True)
         program_type = episode.get('programType')
 
         # Reverse sort seasons if program_type is 'reeksaflopend' or 'daily'
@@ -173,7 +172,13 @@ class ApiHelper:
                 label=localize(30133),  # All seasons
                 path=url_for('programs', program=program, season='allseasons'),
                 art_dict=self._metadata.get_art(episode, season='allseasons'),
-                info_dict=info_labels,
+                info_dict=dict(tvshowtitle=self._metadata.get_tvshowtitle(episode),
+                               plot=self._metadata.get_plot(episode, season='allseasons'),
+                               plotoutline=self._metadata.get_plotoutline(episode, season='allseasons'),
+                               tagline=self._metadata.get_plotoutline(episode, season='allseasons'),
+                               mediatype=self._metadata.get_mediatype(episode, season='allseasons'),
+                               studio=self._metadata.get_studio(episode),
+                               tag=self._metadata.get_tag(episode)),
             ))
 
         # NOTE: Sort the episodes ourselves, because Kodi does not allow to set to 'ascending'
@@ -192,7 +197,7 @@ class ApiHelper:
                 label=label,
                 path=url_for('programs', program=program, season=season_key),
                 art_dict=self._metadata.get_art(episode, season=True),
-                info_dict=info_labels,
+                info_dict=self._metadata.get_info_labels(episode, season=True),
                 prop_dict=self._metadata.get_properties(episode),
             ))
         return season_items, sort, ascending, content

--- a/tests/test_apihelper.py
+++ b/tests/test_apihelper.py
@@ -43,7 +43,7 @@ class TestApiHelper(unittest.TestCase):
         self.assertTrue(len(title_items) < 5)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
-        self.assertEqual(content, 'seasons')
+        self.assertEqual(content, 'files')
 
     def test_get_api_data_specific_season(self):
         """Test listing episodes for a specific season (pano)"""
@@ -51,7 +51,7 @@ class TestApiHelper(unittest.TestCase):
         self.assertEqual(len(title_items), 6)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
-        self.assertEqual(content, 'seasons')
+        self.assertEqual(content, 'files')
 
     def test_get_api_data_specific_season_without_broadcastdate(self):
         """Test listing episodes without broadcast date (postbus-x)"""
@@ -59,7 +59,7 @@ class TestApiHelper(unittest.TestCase):
         self.assertEqual(len(title_items), 4)
         self.assertEqual(sort, 'label')
         self.assertTrue(ascending)
-        self.assertEqual(content, 'seasons')
+        self.assertEqual(content, 'files')
 
     def test_get_recent_episodes(self):
         """Test items, sort and order"""

--- a/tests/test_vrtplayer.py
+++ b/tests/test_vrtplayer.py
@@ -56,7 +56,7 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertTrue(episode_items)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
-        self.assertEqual(content, 'seasons')
+        self.assertEqual(content, 'files')
 
         self._vrtplayer.show_episodes_menu(program)
 
@@ -67,7 +67,7 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertTrue(episode_items, msg=program)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
-        self.assertEqual(content, 'seasons')
+        self.assertEqual(content, 'files')
 
         self._vrtplayer.show_episodes_menu(program)
 


### PR DESCRIPTION
This fixes https://github.com/add-ons/plugin.video.vrt.nu/issues/783

It turned out that `seasons` is not a valid `xbmcplugin.setContent` type and this caused problems with the Arctic Horizon skin