### PR TITLE
Fix getting cache paths

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -708,13 +708,15 @@ def colour(text):
 
 def get_cache_path(cache_file, cache_dir=DEFAULT_CACHE_DIR):
     """Return a specified cache path"""
+    import os
     cache_dir = get_cache_dir(cache_dir)
-    return cache_dir + '/' + cache_file
+    return os.path.join(cache_dir, cache_file)
 
 
 def get_cache_dir(cache_dir=DEFAULT_CACHE_DIR):
     """Create and return a specified cache directory"""
-    cache_dir = addon_profile() + cache_dir
+    import os
+    cache_dir = os.path.join(addon_profile(), cache_dir, '')
     return cache_dir
 
 


### PR DESCRIPTION
Deleting tokens was broken since https://github.com/add-ons/plugin.video.vrt.nu/commit/3fbd36c3fe3a63cca73002ef7f042904ed2dc04f
This fixes this again.