### PR TITLE
Return to directory listing when stream is None

### DIFF
--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -371,5 +371,6 @@ class VRTPlayer:
         _streamservice = StreamService(_tokenresolver)
         stream = _streamservice.get_stream(video)
         if stream is None:
+            end_of_directory()
             return
         play(stream, video.get('listitem'))


### PR DESCRIPTION
If there is no valid stream to play with Kodi Player, we should always return to the directory listing. Otherwise a busy dialog is shown forever.