### PR TITLE
Fix unwanted virtual subclip behaviour

### DIFF
--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -9,7 +9,7 @@ from xbmc import getInfoLabel, Player, PlayList
 from apihelper import ApiHelper
 from data import CHANNELS
 from favorites import Favorites
-from kodiutils import addon_id, get_setting_bool, has_addon, kodi_version_major, log, notify, set_property
+from kodiutils import addon_id, get_setting_bool, has_addon, jsonrpc, kodi_version_major, log, log_error, notify, set_property
 from resumepoints import ResumePoints
 from utils import play_url_to_id, to_unicode, url_to_episode
 
@@ -102,6 +102,7 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
         if not self.listen:
             return
         log(3, '[PlayerInfo {id}] Event onAVStarted', id=self.thread_id)
+        self.virtualsubclip_seektozero()
         self.quit.clear()
         self.update_position()
         self.update_total()
@@ -223,6 +224,43 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
             self.last_pos = self.getTime()
         except RuntimeError:
             pass
+
+    def virtualsubclip_seektozero(self):
+        """VRT NU already offers some programs (mostly current affairs programs) as video on demand while the program is still being broadcasted live.
+           To do so, a start timestamp is added to the livestream url so the Unified Origin streaming platform knows
+           it should return a time bounded manifest file that indicates the beginning of the program.
+           This is called a Live-to-VOD stream or virtual subclip: https://docs.unified-streaming.com/documentation/vod/player-urls.html#virtual-subclips
+           e.g. https://live-cf-vrt.akamaized.net/groupc/live/8edf3bdf-7db3-41c3-a318-72cb7f82de66/live.isml/.mpd?t=2020-07-20T11:07:00
+
+           For some unclear reason the virtual subclip defined by a single start timestamp still behaves as a ordinary livestream
+           and starts at the live edge of the stream. It seems this is not a Kodi or Inputstream Adaptive bug, because other players
+           like THEOplayer or DASH-IF's reference player treat this kind of manifest files the same way.
+           The only difference is that seeking to the beginning of the program is possible. So if the url contains a single start timestamp,
+           we can work around this problem by automatically seeking to the beginning of the program.
+        """
+        playing_file = self.getPlayingFile()
+        if '?t=' in playing_file:
+            try:  # Python 3
+                from urllib.parse import parse_qs, urlsplit
+            except ImportError:  # Python 2
+                from urlparse import parse_qs, urlsplit
+            import re
+            # Detect single start timestamp
+            timestamp = parse_qs(urlsplit(playing_file).query).get('t')[0]
+            rgx = re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$')
+            is_single_start_timestamp = bool(re.match(rgx, timestamp))
+            if is_single_start_timestamp:
+                # Check resume status
+                resume_info = jsonrpc(method='Player.GetItem', params=dict(playerid=1, properties=['resume'])).get('result')
+                if resume_info:
+                    resume_position = resume_info.get('item').get('resume').get('position')
+                    is_resumed = abs(resume_position - self.getTime()) < 1
+                    # Seek to zero if the user didn't resume the program
+                    if not is_resumed:
+                        log(3, '[PlayerInfo {id}] Virtual subclip: seeking to the beginning of the program', id=self.thread_id)
+                        self.seekTime(0)
+                else:
+                    log_error('Failed to start virtual subclip {playing_file} at start timestamp', playing_file=playing_file)
 
     def update_total(self):
         """Update the total video time"""

--- a/tests/test_streamservice.py
+++ b/tests/test_streamservice.py
@@ -72,22 +72,6 @@ class TestStreamService(unittest.TestCase):
         stream = self._streamservice.get_stream(video)
         self.assertTrue(stream is not None)
 
-    @unittest.skipUnless(addon.settings.get('username'), 'Skipping as VRT username is missing.')
-    @unittest.skipUnless(addon.settings.get('password'), 'Skipping as VRT password is missing.')
-    def test_get_journaal_stream_from_url_test_virtual_subclip_format(self):
-        """Test if virtual subclip stream_url has a past stop timestamp"""
-        video = dict(video_url='https://www.vrt.be/vrtnu/a-z/het-journaal.relevant/',
-                     video_id=None,
-                     publication_id=None)
-        stream = self._streamservice.get_stream(video)
-        if '?t=' in stream.stream_url:
-            import re
-            timestamps = stream.stream_url.split('?t=')[1]
-            rgx = re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}')
-            end_time = dateutil.parser.parse(timestamps[20:39], default=datetime.now(dateutil.tz.UTC))
-            self.assertTrue(bool(re.match(rgx, timestamps)))
-            self.assertTrue(bool(end_time < now))
-
     def test_get_mpd_live_stream_from_url_does_not_crash_returns_stream_and_licensekey(self):
         """Test getting MPD stream from URL"""
         addon.settings['usedrm'] = True


### PR DESCRIPTION
This fixes https://github.com/add-ons/plugin.video.vrt.nu/issues/281

This should be tested thoroughly during live broadcasts of "Het Journaal" (preferably 10 minutes after the live broadcast has started using the "Most recent" menu)
- 13:00 CEST: Het journaal 13u 
- 19:00 CEST: Het journaal 19u
- Sometime after 22:00 CEST: Het journaal Laat

This fix only works with InputStream Adaptive (when Widevine DRM is enablad in the add-on settings)