### PR TITLE
Fix apihelper test for episodes without broadcastDate

### DIFF
--- a/tests/test_apihelper.py
+++ b/tests/test_apihelper.py
@@ -54,12 +54,12 @@ class TestApiHelper(unittest.TestCase):
         self.assertEqual(content, 'files')
 
     def test_get_api_data_specific_season_without_broadcastdate(self):
-        """Test listing episodes without broadcast date (postbus-x)"""
-        title_items, sort, ascending, content = self._apihelper.list_episodes(program='postbus-x')
-        self.assertEqual(len(title_items), 3)
-        self.assertEqual(sort, 'label')
+        """Test listing episodes without broadcastDate (wereldbeeld)"""
+        title_items, sort, ascending, content = self._apihelper.list_episodes(program='wereldbeeld')
+        self.assertEqual(len(title_items), 7)
+        self.assertEqual(sort, 'episode')
         self.assertTrue(ascending)
-        self.assertEqual(content, 'files')
+        self.assertEqual(content, 'episodes')
 
     def test_get_recent_episodes(self):
         """Test items, sort and order"""


### PR DESCRIPTION
VRT completed the metadata for Postbus X (https://vrtnu-api.vrt.be/search?facets[programName]=postbus-x) and this program can't no longer be used for the "without broadcastDate" test.
Wereldbeeld is now used to test episodes without broadcastDate.