### PR TITLE
Fix exception on SSLError/log_error

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -1123,9 +1123,19 @@ def open_url(url, data=None, headers=None, method=None, cookiejar=None, follow_r
         ok_dialog(heading=localize(30968), message=localize(30969))
         log_error('URLError: {error}\nurl: {url}', error=exc.reason, url=url)
         return None
-    except (timeout, SSLError) as exc:
+    except SSLError as exc:
+        # TODO: Include the error message in the notification window
         ok_dialog(heading=localize(30968), message=localize(30969))
-        log_error('{error}\nurl: {url}', error=exc.reason, url=url)
+        if hasattr(exc, 'reason'):  # Python 2.7.9+, but still failed on Python 2.7.16
+            log_error('SSLError: {error} ({library})\nurl: {url}', error=exc.reason, library=exc.library, url=url)
+        elif isinstance(exc, list):
+            log_error('SSLError: {error} ({errno})\nurl: {url}', errno=exc[0], error=exc[1], url=url)
+        else:
+            log_error('SSLError: {error}\nurl: {url}', error=str(exc), url=url)
+        return None
+    except timeout as exc:
+        ok_dialog(heading=localize(30968), message=localize(30969))
+        log_error('Timeout: {error}\nurl: {url}', error=exc.reason, url=url)
         return None
 
 


### PR DESCRIPTION
I experienced the following exception:

```
                                              File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/kodiutils.py", line 1128, in open_url
                                                log_error('{error}\nurl: {url}', error=exc.reason, url=url)
                                            AttributeError: 'SSLError' object has no attribute 'reason'
```

What is strange is that this is on a Python 2.7.16 (LibreELEC v9.2.8)
while according to the documentation this should not be happening.

I implemented 2 workarounds, based on possible values for 2.7.8 and
earlier releases.