### PR TITLE
Fix a known exception in TokenResolver

### DIFF
--- a/resources/lib/tokenresolver.py
+++ b/resources/lib/tokenresolver.py
@@ -158,7 +158,11 @@ class TokenResolver:
             _csrf=xsrf.value
         )
         data = urlencode(payload).encode()
-        destination = open_url(self._VRT_LOGIN_URL, data=data, cookiejar=cookiejar).geturl()
+        response = open_url(self._VRT_LOGIN_URL, data=data, cookiejar=cookiejar)
+        if response is None:
+            return None
+
+        destination = response.geturl()
         usertoken = TokenResolver._create_token_dictionary(cookiejar, name)
         if not usertoken and not destination.startswith('https://www.vrt.be/vrtnu'):
             if roaming is False:


### PR DESCRIPTION
This is occuring in our automated testing (when VRT NU is having problems?).

This fixes the issue seen in: https://github.com/add-ons/plugin.video.vrt.nu/runs/1048178157

```log
======================================================================
ERROR: test_get_continue_episodes (test_resumepoints.TestResumePoints)
Test items, sort and order
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/plugin.video.vrt.nu/plugin.video.vrt.nu/tests/test_resumepoints.py", line 46, in test_get_continue_episodes
    self._resumepoints.update(
  File "/home/runner/work/plugin.video.vrt.nu/plugin.video.vrt.nu/resources/lib/resumepoints.py", line 66, in update
    self.refresh(ttl=5)
  File "/home/runner/work/plugin.video.vrt.nu/plugin.video.vrt.nu/resources/lib/resumepoints.py", line 55, in refresh
    headers = self.resumepoint_headers()
  File "/home/runner/work/plugin.video.vrt.nu/plugin.video.vrt.nu/resources/lib/resumepoints.py", line 34, in resumepoint_headers
    xvrttoken = TokenResolver().get_token('X-VRT-Token', variant='user')
  File "/home/runner/work/plugin.video.vrt.nu/plugin.video.vrt.nu/resources/lib/tokenresolver.py", line 242, in get_token
    token = self._get_new_token(name, variant, url, roaming)
  File "/home/runner/work/plugin.video.vrt.nu/plugin.video.vrt.nu/resources/lib/tokenresolver.py", line 132, in _get_new_token
    return self._get_usertoken('X-VRT-Token', login_json=login_json)
  File "/home/runner/work/plugin.video.vrt.nu/plugin.video.vrt.nu/resources/lib/tokenresolver.py", line 161, in _get_usertoken
    destination = open_url(self._VRT_LOGIN_URL, data=data, cookiejar=cookiejar).geturl()
AttributeError: 'NoneType' object has no attribute 'geturl'

----------------------------------------------------------------------
Ran 1 test in 1.815s
```