### PR TITLE
Fix integrated landscape view in Arctic Horizon skin

### DIFF
--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -162,7 +162,7 @@ class ApiHelper:
         season_items = []
         sort = 'label'
         ascending = True
-        content = 'files'
+        content = 'seasons'
 
         episode = random.choice(episodes)
         program_type = episode.get('programType')
@@ -668,7 +668,7 @@ class ApiHelper:
                 label = channel.get('label')
                 plot = '[B]%s[/B]' % channel.get('label')
                 is_playable = False
-                info_dict = dict(title=label, plot=plot, studio=channel.get('studio'), mediatype='video')
+                info_dict = dict(title=label, plot=plot, studio=channel.get('studio'))
                 stream_dict = []
                 prop_dict = {}
             elif channel.get('live_stream') or channel.get('live_stream_id'):
@@ -691,7 +691,7 @@ class ApiHelper:
                 else:
                     plot = localize(30142, **channel)  # Watch live
                 # NOTE: Playcount and resumetime are required to not have live streams as "Watched" and resumed
-                info_dict = dict(title=label, plot=plot, studio=channel.get('studio'), mediatype='video', playcount=0, duration=0)
+                info_dict = dict(title=label, plot=plot, studio=channel.get('studio'), playcount=0, duration=0)
                 prop_dict = dict(resumetime=0)
                 stream_dict = dict(duration=0)
                 context_menu.append((
@@ -744,7 +744,7 @@ class ApiHelper:
                     label = '[B]%s[/B]' % label
                 plot = localize(30144, **youtube)  # Watch on YouTube
                 # NOTE: Playcount is required to not have live streams as "Watched"
-                info_dict = dict(title=label, plot=plot, studio=channel.get('studio'), mediatype='video', playcount=0)
+                info_dict = dict(title=label, plot=plot, studio=channel.get('studio'), playcount=0)
 
                 context_menu = [(
                     localize(30413),  # Refresh menu
@@ -773,7 +773,7 @@ class ApiHelper:
                 label=featured_name,
                 path=url_for('featured', feature=feature.get('id')),
                 art_dict=dict(thumb='DefaultCountry.png'),
-                info_dict=dict(plot='[B]%s[/B]' % feature.get('name'), studio='VRT'),
+                info_dict=dict(title=feature.get('name'), plot='[B]%s[/B]' % feature.get('name'), studio='VRT'),
             ))
         return featured_items
 
@@ -844,8 +844,8 @@ class ApiHelper:
             category_items.append(TitleItem(
                 label=category.get('name'),
                 path=url_for('categories', category=category.get('id')),
-                art_dict=dict(thumb=thumbnail, icon='DefaultGenre.png'),
-                info_dict=dict(plot='[B]%s[/B]' % category.get('name'), studio='VRT'),
+                art_dict=dict(thumb=thumbnail, fanart=thumbnail, icon='DefaultGenre.png'),
+                info_dict=dict(title=category.get('name'), plot='[B]%s[/B]' % category.get('name'), studio='VRT'),
             ))
         return category_items
 

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -547,12 +547,14 @@ class Metadata:
         return ''
 
     def get_mediatype(self, api_data, season=False):
-        """Get art dict from single item json api data"""
+        """Get mediatype from single item json api data"""
 
         # VRT NU Search API
         if api_data.get('type') == 'episode':
+
+            # Don't set mediatype on seasons to get a folder icon in the Kodi skin
             if season is not False:
-                return 'season'
+                return ''
 
             # If this is a oneoff (e.g. movie) and we get a year of release, do not set 'aired'
             if api_data.get('programType') == 'oneoff' and self.get_year(api_data):

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -35,47 +35,47 @@ class VRTPlayer:
             main_items.append(TitleItem(
                 label=localize(30010),  # My favorites
                 path=url_for('favorites_menu'),
-                art_dict=dict(thumb='DefaultFavourites.png'),
-                info_dict=dict(plot=localize(30011)),
+                art_dict=dict(thumb='DefaultFavourites.png', fanart='DefaultFavourites.png'),
+                info_dict=dict(title=localize(30010), plot=localize(30011)),
             ))
 
         main_items.extend([
             TitleItem(label=localize(30012),  # All programs
                       path=url_for('programs'),
-                      art_dict=dict(thumb='DefaultMovieTitle.png'),
-                      info_dict=dict(plot=localize(30013))),
+                      art_dict=dict(thumb='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
+                      info_dict=dict(title=localize(30012), plot=localize(30013))),
             TitleItem(label=localize(30014),  # Categories
                       path=url_for('categories'),
-                      art_dict=dict(thumb='DefaultGenre.png'),
-                      info_dict=dict(plot=localize(30015))),
+                      art_dict=dict(thumb='DefaultGenre.png', fanart='DefaultGenre.png'),
+                      info_dict=dict(title=localize(30014), plot=localize(30015))),
             TitleItem(label=localize(30016),  # Channels
                       path=url_for('channels'),
-                      art_dict=dict(thumb='DefaultTags.png'),
-                      info_dict=dict(plot=localize(30017))),
+                      art_dict=dict(thumb='DefaultTags.png', fanart='DefaultTags.png'),
+                      info_dict=dict(title=localize(30016), plot=localize(30017))),
             TitleItem(label=localize(30018),  # Live TV
                       path=url_for('livetv'),
-                      art_dict=dict(thumb='DefaultTVShows.png'),
-                      info_dict=dict(plot=localize(30019))),
+                      art_dict=dict(thumb='DefaultTVShows.png', fanart='DefaultTVShows.png'),
+                      info_dict=dict(title=localize(30018), plot=localize(30019))),
             TitleItem(label=localize(30020),  # Recent items
                       path=url_for('recent'),
-                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
-                      info_dict=dict(plot=localize(30021))),
+                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
+                      info_dict=dict(title=localize(30020), plot=localize(30021))),
             TitleItem(label=localize(30022),  # Soon offline
                       path=url_for('offline'),
-                      art_dict=dict(thumb='DefaultYear.png'),
-                      info_dict=dict(plot=localize(30023))),
+                      art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
+                      info_dict=dict(title=localize(30022), plot=localize(30023))),
             TitleItem(label=localize(30024),  # Featured content
                       path=url_for('featured'),
-                      art_dict=dict(thumb='DefaultCountry.png'),
-                      info_dict=dict(plot=localize(30025))),
+                      art_dict=dict(thumb='DefaultCountry.png', fanart='DefaultCountry.png'),
+                      info_dict=dict(title=localize(30024), plot=localize(30025))),
             TitleItem(label=localize(30026),  # TV guide
                       path=url_for('tvguide'),
-                      art_dict=dict(thumb='DefaultAddonTvInfo.png'),
-                      info_dict=dict(plot=localize(30027))),
+                      art_dict=dict(thumb='DefaultAddonTvInfo.png', fanart='DefaultAddonTvInfo.png'),
+                      info_dict=dict(title=localize(30026), plot=localize(30027))),
             TitleItem(label=localize(30028),  # Search
                       path=url_for('search'),
-                      art_dict=dict(thumb='DefaultAddonsSearch.png'),
-                      info_dict=dict(plot=localize(30029))),
+                      art_dict=dict(thumb='DefaultAddonsSearch.png', fanart='DefaultAddonsSearch.png'),
+                      info_dict=dict(title=localize(30028), plot=localize(30029))),
         ])
         show_listing(main_items, cache=False)  # No category
         self._version_check()
@@ -126,16 +126,16 @@ class VRTPlayer:
         favorites_items = [
             TitleItem(label=localize(30040),  # My programs
                       path=url_for('favorites_programs'),
-                      art_dict=dict(thumb='DefaultMovieTitle.png'),
-                      info_dict=dict(plot=localize(30041))),
+                      art_dict=dict(thumb='DefaultMovieTitle.png', fanart='DefaultMovieTitle.png'),
+                      info_dict=dict(title=localize(30040), plot=localize(30041))),
             TitleItem(label=localize(30048),  # My recent items
                       path=url_for('favorites_recent'),
-                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png'),
-                      info_dict=dict(plot=localize(30049))),
+                      art_dict=dict(thumb='DefaultRecentlyAddedEpisodes.png', fanart='DefaultRecentlyAddedEpisodes.png'),
+                      info_dict=dict(title=localize(30048), plot=localize(30049))),
             TitleItem(label=localize(30050),  # My soon offline
                       path=url_for('favorites_offline'),
-                      art_dict=dict(thumb='DefaultYear.png'),
-                      info_dict=dict(plot=localize(30051))),
+                      art_dict=dict(thumb='DefaultYear.png', fanart='DefaultYear.png'),
+                      info_dict=dict(title=localize(30050), plot=localize(30051))),
         ]
 
         # Only add 'My watch later' and 'Continue watching' when it has been activated
@@ -143,38 +143,38 @@ class VRTPlayer:
             favorites_items.append(TitleItem(
                 label=localize(30052),  # My watch later
                 path=url_for('resumepoints_watchlater'),
-                art_dict=dict(thumb='DefaultVideoPlaylists.png'),
-                info_dict=dict(plot=localize(30053)),
+                art_dict=dict(thumb='DefaultVideoPlaylists.png', fanart='DefaultVideoPlaylists.png'),
+                info_dict=dict(title=localize(30052), plot=localize(30053)),
             ))
             favorites_items.append(TitleItem(
                 label=localize(30054),  # Continue Watching
                 path=url_for('resumepoints_continue'),
-                art_dict=dict(thumb='DefaultInProgressShows.png'),
-                info_dict=dict(plot=localize(30055)),
+                art_dict=dict(thumb='DefaultInProgressShows.png', fanart='DefaultInProgressShows.png'),
+                info_dict=dict(title=localize(30054), plot=localize(30055)),
             ))
 
         if get_setting_bool('addmymovies', default=True):
             favorites_items.append(
                 TitleItem(label=localize(30042),  # My movies
                           path=url_for('categories', category='films'),
-                          art_dict=dict(thumb='DefaultAddonVideo.png'),
-                          info_dict=dict(plot=localize(30043))),
+                          art_dict=dict(thumb='DefaultAddonVideo.png', fanart='DefaultAddonVideo.png'),
+                          info_dict=dict(title=localize(30042), plot=localize(30043))),
             )
 
         if get_setting_bool('addmydocu', default=True):
             favorites_items.append(
                 TitleItem(label=localize(30044),  # My documentaries
                           path=url_for('favorites_docu'),
-                          art_dict=dict(thumb='DefaultMovies.png'),
-                          info_dict=dict(plot=localize(30045))),
+                          art_dict=dict(thumb='DefaultMovies.png', fanart='DefaultMovies.png'),
+                          info_dict=dict(title=localize(30044), plot=localize(30045))),
             )
 
         if get_setting_bool('addmymusic', default=True):
             favorites_items.append(
                 TitleItem(label=localize(30046),  # My music
                           path=url_for('favorites_music'),
-                          art_dict=dict(thumb='DefaultAddonMusic.png'),
-                          info_dict=dict(plot=localize(30047))),
+                          art_dict=dict(thumb='DefaultAddonMusic.png', fanart='DefaultAddonMusic.png'),
+                          info_dict=dict(title=localize(30046), plot=localize(30047))),
             )
 
         show_listing(favorites_items, category=30010, cache=False)  # My favorites
@@ -216,7 +216,7 @@ class VRTPlayer:
             show_listing(tvshow_items, category=category_msgctxt, sort='label', content='tvshows')
         else:
             category_items = self._apihelper.list_categories()
-            show_listing(category_items, category=30014, sort='unsorted', content='tvshows')  # Categories
+            show_listing(category_items, category=30014, sort='unsorted', content='videos')  # Categories
 
     def show_channels_menu(self, channel=None):
         """The VRT NU add-on 'Channels' listing menu"""
@@ -246,7 +246,7 @@ class VRTPlayer:
             show_listing(tvshow_items, category=feature_msgctxt, sort='label', content='tvshows', cache=False)
         else:
             featured_items = self._apihelper.list_featured()
-            show_listing(featured_items, category=30024, sort='label', content='files')
+            show_listing(featured_items, category=30024, sort='label', content='videos')
 
     def show_livetv_menu(self):
         """The VRT NU add-on 'Live TV' listing menu"""

--- a/resources/lib/vrtplayer.py
+++ b/resources/lib/vrtplayer.py
@@ -216,7 +216,7 @@ class VRTPlayer:
             show_listing(tvshow_items, category=category_msgctxt, sort='label', content='tvshows')
         else:
             category_items = self._apihelper.list_categories()
-            show_listing(category_items, category=30014, sort='unsorted', content='files')  # Categories
+            show_listing(category_items, category=30014, sort='unsorted', content='tvshows')  # Categories
 
     def show_channels_menu(self, channel=None):
         """The VRT NU add-on 'Channels' listing menu"""

--- a/tests/test_apihelper.py
+++ b/tests/test_apihelper.py
@@ -43,7 +43,7 @@ class TestApiHelper(unittest.TestCase):
         self.assertTrue(5 < len(title_items) < 10)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
-        self.assertEqual(content, 'files')
+        self.assertEqual(content, 'seasons')
 
     def test_get_api_data_specific_season(self):
         """Test listing episodes for a specific season (pano)"""
@@ -51,7 +51,7 @@ class TestApiHelper(unittest.TestCase):
         self.assertEqual(len(title_items), 6)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
-        self.assertEqual(content, 'files')
+        self.assertEqual(content, 'seasons')
 
     def test_get_api_data_specific_season_without_broadcastdate(self):
         """Test listing episodes without broadcastDate (wereldbeeld)"""

--- a/tests/test_vrtplayer.py
+++ b/tests/test_vrtplayer.py
@@ -61,7 +61,7 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertTrue(episode_items)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
-        self.assertEqual(content, 'files')
+        self.assertEqual(content, 'seasons')
 
         self._vrtplayer.show_episodes_menu(program)
 
@@ -72,7 +72,7 @@ class TestVRTPlayer(unittest.TestCase):
         self.assertTrue(episode_items, msg=program)
         self.assertEqual(sort, 'label')
         self.assertFalse(ascending)
-        self.assertEqual(content, 'files')
+        self.assertEqual(content, 'seasons')
 
         self._vrtplayer.show_episodes_menu(program)
 
@@ -92,7 +92,7 @@ class TestVRTPlayer(unittest.TestCase):
             self.assertTrue(episode_items, msg=tvshow.path.split('/')[4])
             self.assertTrue(sort in ['dateadded', 'episode', 'label', 'unsorted'])
             self.assertTrue(ascending is True or ascending is False)
-            self.assertTrue(content in ['episodes', 'files'], "Content for '%s' is '%s'" % (tvshow.label, content))
+            self.assertTrue(content in ['episodes', 'seasons'], "Content for '%s' is '%s'" % (tvshow.label, content))
         elif tvshow.path.startswith('plugin://plugin.video.vrt.nu/play/id/'):
             # When random program is playable item
             pass

--- a/tests/xbmcplugin.py
+++ b/tests/xbmcplugin.py
@@ -101,7 +101,7 @@ def getSetting(handle, key):
 
 def setContent(handle, content):
     """A stub implementation of the xbmcplugin setContent() function"""
-    assert content in ['albums', 'artists', 'episodes', 'files', 'games', 'images', 'movies', 'musicvideos', 'songs', 'tvshows', 'videos']
+    assert content in ['albums', 'artists', 'episodes', 'files', 'games', 'images', 'movies', 'musicvideos', 'seasons', 'songs', 'tvshows', 'videos']
 
 
 def setPluginFanart(handle, image, color1=None, color2=None, color3=None):


### PR DESCRIPTION
This fixes https://github.com/add-ons/plugin.video.vrt.nu/issues/822 and reintroduces https://github.com/add-ons/plugin.video.vrt.nu/issues/783

Using `xbmcplugin.setContent('seasons')` enables the Integrated Landscape View, but in that case [Arctic Horizon skin](https://github.com/jurialmunkey/skin.arctic.horizon) doesn't pick up the `ListItem` metadata in Kodi Player, so this PR introduces https://github.com/add-ons/plugin.video.vrt.nu/issues/783 again.