### PR TITLE
Document the different workflows

### DIFF
--- a/.github/workflows/addon-check.yml
+++ b/.github/workflows/addon-check.yml
@@ -1,3 +1,6 @@
+# This workflow performs the required add-on checks for a submission
+# to the official Kodi repository
+
 name: Kodi
 on:
 - pull_request

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,7 @@
+# This workflow performs the various sanity tests, integration tests and
+# may run parts of the add-on and add-on service to get a better testing
+# coverage. It also runs Codecov and SonarCloud actions.
+
 name: CI
 on:
 - pull_request

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# This workflow performs an automated release to GitHub and to the official
+# Kodi repository, for a pre-Matrix and a post-Matrix release.
+
 name: Release
 on:
   push:

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -1,3 +1,7 @@
+# This workflow performs status checks to identify broken code paths due to
+# backend changes. It tests authentication, resumepoints, search, suggest,
+# TV guide, webscrapers and reports new Android app releases.
+
 name: Status
 on:
   pull_request:


### PR DESCRIPTION
Since we use the VRT NU workflows as a best practice, we might as well
document better what each of them is doing.