### PR TITLE
A better fix for a missing category

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -368,6 +368,8 @@ def set_locale():
 
 def localize(string_id, **kwargs):
     """Return the translated string from the .po language files, optionally translating variables"""
+    if not isinstance(string_id, int) and not string_id.isdecimal():
+        return string_id
     if kwargs:
         from string import Formatter
         return Formatter().vformat(ADDON.getLocalizedString(string_id), (), SafeDict(**kwargs))

--- a/resources/lib/metadata.py
+++ b/resources/lib/metadata.py
@@ -797,7 +797,7 @@ class Metadata:
         # VRT NU Search API
         if api_data.get('type') == 'episode':
             from data import CATEGORIES
-            return sorted([localize(find_entry(CATEGORIES, 'id', category, {}).get('msgctxt', 30135))
+            return sorted([localize(find_entry(CATEGORIES, 'id', category, {}).get('msgctxt', category))
                            for category in api_data.get('categories', [])])
 
         # VRT NU Suggest API


### PR DESCRIPTION
Rather than returning 'Not found' we return the untranslated string.