### PR TITLE
Allow to install and run Kodi Logfile Uploader from the settings

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -897,6 +897,14 @@ msgctxt "#30933"
 msgid "Log level"
 msgstr ""
 
+msgctxt "#30935"
+msgid "Install Kodi Logfile Uploader…"
+msgstr ""
+
+msgctxt "#30937"
+msgid "Open Kodi Logfile Uploader…"
+msgstr ""
+
 
 ### MESSAGES
 msgctxt "#30951"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -897,6 +897,14 @@ msgctxt "#30933"
 msgid "Log level"
 msgstr "Log niveau"
 
+msgctxt "#30935"
+msgid "Install Kodi Logfile Uploader…"
+msgstr "Installeer Kodi Logfile Uploader…"
+
+msgctxt "#30937"
+msgid "Open Kodi Logfile Uploader…"
+msgstr "Open Kodi Logfile Uploader…"
+
 
 ### MESSAGES
 msgctxt "#30951"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -92,5 +92,7 @@
         <setting label="30929" help="30930" type="slider" id="httpcachettlindirect" default="60" range="1,1,240" option="int" enable="eq(-3,true)" subsetting="true"/>
         <setting label="30931" type="lsep"/> <!-- Logging -->
         <setting label="30933" help="30934" type="enum" id="max_log_level" lvalues="30430|30431|30432|30433" default="0"/>
+        <setting label="30935" help="30936" type="action" action="InstallAddon(script.kodi.loguploader)" option="close" visible="!System.HasAddon(script.kodi.loguploader)"/> <!-- Install Kodi Logfile Uploader -->
+        <setting label="30937" help="30938" type="action" action="RunAddon(script.kodi.loguploader)" visible="String.StartsWith(System.BuildVersion,18) + System.HasAddon(script.kodi.loguploader) | System.AddonIsEnabled(script.kodi.loguploader)" /> <!-- Open Kodi Logfile Uploader -->
     </category>
 </settings>


### PR DESCRIPTION
This adds an item to the Expert settings to allow users to view or upload their kodi log using the **Kodi Logfile Uploader** Add-on. This makes it easier to troubleshoot issues on systems where the log is difficult to access, like the new Google Chromecast (Android TV).

It seems that on LibreElec this feature is already integrated in the LibreElec settings.