### PR TITLE
Fix invalid setting type

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -741,6 +741,10 @@ msgctxt "#30834"
 msgid "VRT NWS"
 msgstr ""
 
+msgctxt "#30835"
+msgid "De Warmste Week"
+msgstr ""
+
 msgctxt "#30860"
 msgid "Integration"
 msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -741,6 +741,10 @@ msgctxt "#30834"
 msgid "VRT NWS"
 msgstr "VRT NWS"
 
+msgctxt "#30835"
+msgid "De Warmste Week"
+msgstr "De Warmste Week"
+
 msgctxt "#30860"
 msgid "Integration"
 msgstr "Integratie"

--- a/resources/lib/apihelper.py
+++ b/resources/lib/apihelper.py
@@ -551,7 +551,10 @@ class ApiHelper:
                 program_urls = [program_to_url(p, 'medium') for p in self._favorites.programs()]
                 params['facets[programUrl]'] = '[%s]' % (','.join(program_urls))
             elif variety in ('offline', 'recent'):
-                channel_filter = [channel.get('name') for channel in CHANNELS if get_setting_bool(channel.get('name'), default=True)]
+                channel_filter = []
+                for channel in CHANNELS:
+                    if channel.get('vod') is True and get_setting_bool(channel.get('name'), default=True):
+                        channel_filter.append(channel.get('name'))
                 params['facets[programBrands]'] = '[%s]' % (','.join(channel_filter))
 
         if program:

--- a/resources/lib/data.py
+++ b/resources/lib/data.py
@@ -52,6 +52,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/een/een_LOGO_zwart.png',
         epg_id='een.be',
         preset=1,
+        vod=True,
     ),
     dict(
         id='1H',
@@ -69,6 +70,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/canvas/CANVAS_logo_lichtblauw.jpg',
         epg_id='canvas.be',
         preset=2,
+        vod=True,
     ),
     dict(
         id='O9',
@@ -86,6 +88,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/ketnet/ketnet_LOGO_rood_geel.png',
         epg_id='ketnet.be',
         preset=12,
+        vod=True,
     ),
     dict(
         id='',
@@ -99,6 +102,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/2019/07/19/c309360a-aa10-11e9-abcc-02b7b76bf47f.png',
         epg_id='ketnetjr.be',
         preset=11,
+        vod=True,
     ),
     dict(
         id='12',
@@ -112,6 +116,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/sporza/sporza_logo_zwart.png',
         epg_id='sporza.be',
         preset=801,
+        vod=True,
     ),
     dict(
         id='13',
@@ -127,6 +132,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logos/vrtnws.png',
         epg_id='vrtnws.be',
         preset=802,
+        vod=True,
     ),
     dict(
         id='11',
@@ -141,6 +147,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logos/radio1.png',
         epg_id='radio1.be',
         preset=901,
+        vod=True,
     ),
     dict(
         id='22',
@@ -155,6 +162,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logos/radio2.png',
         epg_id='radio2vlb.be',
         preset=902,
+        vod=True,
     ),
     dict(
         id='31',
@@ -169,6 +177,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logos/klara.png',
         epg_id='klara.be',
         preset=903,
+        vod=True,
     ),
     dict(
         id='41',
@@ -183,6 +192,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/2019/03/12/1e383cf5-44a7-11e9-abcc-02b7b76bf47f.png',
         epg_id='stubru.be',
         preset=904,
+        vod=True,
     ),
     dict(
         id='55',
@@ -197,6 +207,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/mnm/logo_witte_achtergrond.png',
         epg_id='mnm.be',
         preset=905,
+        vod=True,
     ),
     dict(
         id='',
@@ -206,6 +217,7 @@ CHANNELS = [
         youtube=[
             dict(label='VRT NXT', url='https://www.youtube.com/channel/UCO-VoGCVzhYVwvQvWYJq4-Q'),
         ],
+        vod=True,
     ),
     dict(
         id='',
@@ -215,6 +227,7 @@ CHANNELS = [
         youtube=[
             dict(label='De Warmste Week', url='https://www.youtube.com/channel/UC_PsMpKLAp4hSGSXyUCPtxw'),
         ],
+        vod=True,
     ),
     dict(
         id='',
@@ -225,6 +238,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/vrt.png',
         epg_id='vrtevents1.be',
         preset=851,
+        vod=False,
     ),
     dict(
         id='',
@@ -235,6 +249,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/vrt.png',
         epg_id='vrtevents2.be',
         preset=852,
+        vod=False,
     ),
     dict(
         id='',
@@ -245,6 +260,7 @@ CHANNELS = [
         logo='https://images.vrt.be/orig/logo/vrt.png',
         epg_id='vrtevents3.be',
         preset=853,
+        vod=False,
     ),
 ]
 

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -598,7 +598,7 @@ def get_playerid():
 
 def get_max_bandwidth():
     """Get the max bandwidth based on Kodi and add-on settings"""
-    vrtnu_max_bandwidth = get_setting_int('max_bandwidth', default=0)
+    vrtnu_max_bandwidth = int(get_setting('max_bandwidth', default='0'))
     global_max_bandwidth = int(get_global_setting('network.bandwidth'))
     if vrtnu_max_bandwidth != 0 and global_max_bandwidth != 0:
         return min(vrtnu_max_bandwidth, global_max_bandwidth)

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -471,15 +471,12 @@ def get_setting_int(key, default=None):
 
 
 def get_setting_float(key, default=None):
-    """Get an add-on setting"""
+    """Get an add-on setting as float"""
+    value = get_setting(key, default)
     try:
-        return ADDON.getSettingNumber(key)
-    except (AttributeError, TypeError):  # On Krypton or older, or when not a float
-        value = get_setting(key, default)
-        try:
-            return float(value)
-        except ValueError:
-            return default
+        return float(value)
+    except ValueError:
+        return default
     except RuntimeError:  # Occurs when the add-on is disabled
         return default
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -49,6 +49,7 @@
         <setting label="30832" type="bool" id="mnm" default="true"/> <!-- MNM -->
         <setting label="30833" type="bool" id="vrtnws" default="true"/> <!-- VRT NWS -->
         <setting label="30834" type="bool" id="vrtnxt" default="true"/> <!-- VRT NXT -->
+        <setting label="30835" type="bool" id="de-warmste-week" default="false"/> <!-- De Warmste Week -->
     </category>
     <category label="30860"> <!--Integration -->
         <setting label="30861" type="lsep"/> <!-- Integration with other add-ons -->


### PR DESCRIPTION
This fixes `EXCEPTION: Invalid setting type` in kodi.log in the following cases:
- when using `get_setting_float`.
- when using the labelenum setting type to select max_bandwith
- in most recent/soon offline menu

I guess `xbmcaddon.getSettingNumber` isn't functional because you can only define an integer type in the Kodi addon settings xml and in addition it is wrongly named as `type="number"`.

Maybe this can be fixed upstream if Team Kodi still accepts changes to the deprecated old settings format:
https://kodi.wiki/view/Add-on_settings#type.3D.22number.22

Relevant source code
https://github.com/xbmc/xbmc/blob/5230b683323ca58c62459a371c1306a6cb4d4644/xbmc/addons/settings/AddonSettings.cpp#L832-L844

`setting->GetType() `can never be a `SettingType::Number`, so it differs from `TSetting::Type()` and returns false
https://github.com/xbmc/xbmc/blob/c4de26b28fb13ce65eb1caac4236d83bd410d112/xbmc/addons/Addon.cpp#L206