### PR TITLE
Fixes a date parsing issue on windows and run CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,26 +9,41 @@ on:
 jobs:
   tests:
     name: Add-on testing
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     env:
       PYTHONIOENCODING: utf-8
       PYTHONPATH: ${{ github.workspace }}/resources/lib:${{ github.workspace }}/tests
     strategy:
       fail-fast: false
       matrix:
-#        max-parallel: 2
+        os: [ubuntu-latest]
         python-version: [ 2.7, 3.5, 3.6, 3.7, 3.8, 3.9 ]
+        include:
+          # Kodi Leia on Windows uses a bundled Python 2.7
+          - os: windows-latest
+            python-version: 2.7
+          # Kodi Matrix on Windows uses a bundled Python 3.8
+          - os: windows-latest
+            python-version: 3.8
+          - os: windows-latest
+            python-version: 3.9
     steps:
     - name: Check out ${{ github.sha }} from repository ${{ github.repository }}
       uses: actions/checkout@v2
+    - name: Setup PYTHONPATH (windows)
+      if: matrix.os == 'windows-latest'
+      run: echo "PYTHONPATH=${env:PYTHONPATH};${env:GITHUB_WORKSPACE};${env:GITHUB_WORKSPACE}\resources\lib;${env:GITHUB_WORKSPACE}\tests" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install dependencies (linux)
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get install gettext
         sudo pip install coverage --install-option="--install-scripts=/usr/bin"
+    - name: Install dependencies
+      run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Run tox
@@ -39,7 +54,7 @@ jobs:
       if: always()
     - name: Compare translations
       run: make check-translations
-      if: always()
+      if: matrix.os == 'ubuntu-latest'
     # Python 2.7 and Python 3.5 are no longer supported by proxy.py
     - name: Start proxy server, when supported
       run: python -m proxy --hostname 127.0.0.1 --log-level DEBUG &
@@ -61,9 +76,11 @@ jobs:
       run: coverage run -a tests/run.py /
       if: always()
     - name: Upload code coverage to CodeCov
+      if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v1
       continue-on-error: true
     - name: Analyze with SonarCloud
+      if: matrix.os == 'ubuntu-latest'
       uses: SonarSource/sonarcloud-github-action@v1.4
       with:
         args: >

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -416,6 +416,11 @@ def localize_date(date, strftime):
         strftime = strftime.replace('%B', MONTH_LONG[date.strftime('%m')])
     elif '%b' in strftime:
         strftime = strftime.replace('%b', MONTH_SHORT[date.strftime('%m')])
+
+    # %e isn't supported on Python 2.7 on Windows
+    if '%e' in strftime:
+        strftime = strftime.replace('%e', str(int(date.strftime('%d'))))
+
     return date.strftime(strftime)
 
 


### PR DESCRIPTION
* Run CI on Windows (Python 2.7, Python 3.8 and Python 3.9)

* Fixes `datelong` formatting that currently is `%A, %e %B %Y`, but `%e` isn't a standard in Python. Under certain situations (like the setup of CI), this doesn't work.