### PR TITLE
Don't log credentials in the Kodi debug log

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -1092,7 +1092,7 @@ def open_url(url, data=None, headers=None, method=None, cookiejar=None, follow_r
         log(2, 'URL post: {url}', url=unquote(url))
         # Make sure we don't log the password
         debug_data = data
-        if 'password' in debug_data:
+        if 'password' in to_unicode(debug_data):
             debug_data = '**redacted**'
         log(2, 'URL post data: {data}', data=debug_data)
     else:

--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -1090,7 +1090,11 @@ def open_url(url, data=None, headers=None, method=None, cookiejar=None, follow_r
     if data is not None:
         req.data = data
         log(2, 'URL post: {url}', url=unquote(url))
-        log(2, 'URL post data: {data}', data=data)
+        # Make sure we don't log the password
+        debug_data = data
+        if 'password' in debug_data:
+            debug_data = '**redacted**'
+        log(2, 'URL post data: {data}', data=debug_data)
     else:
         log(2, 'URL get: {url}', url=unquote(url))
 


### PR DESCRIPTION
This isn't the best way to do this, since it will redact every POST data that contains `password`, but since the data is already in a string format and url-encoded, this is the best I can do.