### PR TITLE
Use InputStream Adaptive to play HLS

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -292,14 +292,23 @@ def play(stream, video=None):
         )
     play_item.setProperty('inputstream.adaptive.max_bandwidth', str(get_max_bandwidth() * 1000))
     play_item.setProperty('network.bandwidth', str(get_max_bandwidth() * 1000))
+
     if stream.stream_url is not None and stream.use_inputstream_adaptive:
         if kodi_version_major() < 19:
             play_item.setProperty('inputstreamaddon', 'inputstream.adaptive')
         else:
             play_item.setProperty('inputstream', 'inputstream.adaptive')
-        play_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
+
         play_item.setContentLookup(False)
-        play_item.setMimeType('application/dash+xml')
+
+        if '.mpd' in stream.stream_url:
+            play_item.setProperty('inputstream.adaptive.manifest_type', 'mpd')
+            play_item.setMimeType('application/dash+xml')
+
+        if '.m3u8' in stream.stream_url:
+            play_item.setProperty('inputstream.adaptive.manifest_type', 'hls')
+            play_item.setMimeType('application/vnd.apple.mpegurl')
+
         if stream.license_key is not None:
             import inputstreamhelper
             is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')

--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -239,7 +239,7 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
            we can work around this problem by automatically seeking to the beginning of the program.
         """
         playing_file = self.getPlayingFile()
-        if '?t=' in playing_file:
+        if any(param in playing_file for param in ('?t=', '&t=')):
             try:  # Python 3
                 from urllib.parse import parse_qs, urlsplit
             except ImportError:  # Python 2

--- a/resources/lib/streamservice.py
+++ b/resources/lib/streamservice.py
@@ -254,7 +254,11 @@ class StreamService:
                 log(2, 'Protocol: {protocol}', protocol=protocol)
                 # Fix 720p quality for HLS livestreams
                 manifest_url = manifest_url.replace('.m3u8?', '.m3u8?hd&') if '.m3u8?' in manifest_url else manifest_url + '?hd'
-                stream = self._select_hls_substreams(manifest_url, protocol)
+                # Play HLS directly in Kodi Player on Kodi 17
+                if kodi_version_major() < 18 or not has_inputstream_adaptive():
+                    stream = self._select_hls_substreams(manifest_url, protocol)
+                else:
+                    stream = StreamURLS(manifest_url, use_inputstream_adaptive=True)
             return stream
 
         # VRT Geoblock: failed to get stream, now try again with roaming enabled
@@ -311,7 +315,7 @@ class StreamService:
         end_of_directory()
 
     def _select_hls_substreams(self, master_hls_url, protocol):
-        """Select HLS substreams to speed up Kodi player start, workaround for slower kodi selection"""
+        """Select HLS substreams to speed up Kodi player start, workaround for slower Kodi selection"""
         hls_variant_url = None
         subtitle_url = None
         hls_audio_id = None


### PR DESCRIPTION
Play all streams using InputStream Adaptive from Kodi 18 onwards. This fixes https://github.com/add-ons/plugin.video.vrt.nu/issues/846

To test this, you need to disable "Use Widevine DRM".