### PR TITLE
Add error message for age restricted content

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1042,3 +1042,7 @@ msgstr ""
 msgctxt "#30989"
 msgid "Failed to load a compatible stream, please try toggling 'Use Widevine DRM' in the add-on Playback settings."
 msgstr ""
+
+msgctxt "#30990"
+msgid "This program cannot be played. Your VRT NU account is not allowed to access 12+ content. Please check your VRT NU account details at https://www.vrt.be/vrtnu/"
+msgstr ""

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -1042,3 +1042,7 @@ msgstr "InputStream Adaptive is niet geïnstalleerd, daarom kan het pauzeren en 
 msgctxt "#30989"
 msgid "Failed to load a compatible stream, please try toggling 'Use Widevine DRM' in the add-on Playback settings."
 msgstr "Kan geen compatibele stream laden, probeer 'Gebruik Widevine DRM' in of uit te schakelen in de add-on afspeelinstellingen."
+
+msgctxt "#30990"
+msgid "This program cannot be played. Your VRT NU account is not allowed to access 12+ content. Please check your VRT NU account details at https://www.vrt.be/vrtnu/"
+msgstr "Dit programma kan niet afgespeeld worden. Je VRT NU-account heeft geen toegang tot 12+ content. Controleer je VRT NU-account details op https://www.vrt.be/vrtnu/"

--- a/resources/lib/streamservice.py
+++ b/resources/lib/streamservice.py
@@ -313,6 +313,9 @@ class StreamService:
             container_reload()
             message = localize(30987)  # No stream found
             return self._handle_stream_api_error(message, stream_json)
+        if stream_json.get('code') == 'ERROR_AGE_RESTRICTED':
+            message = localize(30990)  # Cannot be played, VRT NU account not allowed to access 12+ content
+            return self._handle_stream_api_error(message, stream_json)
 
         # Failed to get stream, handle error
         message = localize(30954)  # Whoops something went wrong


### PR DESCRIPTION
This PR adds a clear error message for VRT NU age restricted content. When your VRT NU account doesn't contain a valid birth date, you can only play content that has no age restriction.