### PR TITLE
A read timeout (socket.timeout) causes exception

### DIFF
--- a/resources/lib/kodiutils.py
+++ b/resources/lib/kodiutils.py
@@ -1161,7 +1161,7 @@ def open_url(url, data=None, headers=None, method=None, cookiejar=None, follow_r
         return None
     except timeout as exc:
         ok_dialog(heading=localize(30968), message=localize(30969))
-        log_error('Timeout: {error}\nurl: {url}', error=exc.reason, url=url)
+        log_error('Timeout: {error}\nurl: {url}', error=exc, url=url)
         return None
 
 


### PR DESCRIPTION
We have seen the following issue when using the VRT NU addon.
Unfortunately, after fixing this I could no longer reproduce the original read timeout to further troubleshoot my issues.

```
2022-02-15 22:24:23.669 T:1214  WARNING <general>: [plugin.video.vrt.nu] Access: plugin://plugin.video.vrt.nu/favorites
2022-02-15 22:24:23.766 T:1214  WARNING <general>: [plugin.video.vrt.nu] Got item from cache '/storage/.kodi/userdata/addon_data/plugin.video.vrt.nu/tokens/vrtloginat.tkn'
2022-02-15 22:24:23.771 T:1214  WARNING <general>: [plugin.video.vrt.nu] URL get: https://www.vrt.be/vrtnu-api/rest/lists/vrtnu-favoritePrograms?tileType=program-poster&tileContentType=program&tileOrientation=portrait&layout=slider&title=Mijn+favoriete+programma's
2022-02-15 22:24:29.097 T:1214    ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'AttributeError'>
                                                   Error Contents: 'timeout' object has no attribute 'reason'
                                                   Traceback (most recent call last):
                                                     File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/kodiutils.py", line 1116, in open_url
                                                       return opener.open(req)
                                                     File "/usr/lib/python3.8/urllib/request.py", line 525, in open
                                                     File "/usr/lib/python3.8/urllib/request.py", line 542, in _open
                                                     File "/usr/lib/python3.8/urllib/request.py", line 502, in _call_chain
                                                     File "/usr/lib/python3.8/urllib/request.py", line 1397, in https_open
                                                     File "/usr/lib/python3.8/urllib/request.py", line 1358, in do_open
                                                     File "/usr/lib/python3.8/http/client.py", line 1344, in getresponse
                                                     File "/usr/lib/python3.8/http/client.py", line 307, in begin
                                                     File "/usr/lib/python3.8/http/client.py", line 268, in _read_status
                                                     File "/usr/lib/python3.8/socket.py", line 669, in readinto
                                                     File "/usr/lib/python3.8/ssl.py", line 1241, in recv_into
                                                     File "/usr/lib/python3.8/ssl.py", line 1099, in read
                                                   socket.timeout: The read operation timed out

                                                   During handling of the above exception, another exception occurred:

                                                   Traceback (most recent call last):
                                                     File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/addon_entry.py", line 14, in <module>
                                                       run(argv)
                                                     File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/addon.py", line 362, in run
                                                       plugin.run(argv)
                                                     File "/storage/.kodi/addons/script.module.routing/lib/routing.py", line 130, in run
                                                       self._dispatch(self.path)
                                                     File "/storage/.kodi/addons/script.module.routing/lib/routing.py", line 141, in _dispatch
                                                       view_func(**kwargs)
                                                     File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/addon.py", line 81, in favorites_menu
                                                       VRTPlayer().show_favorites_menu()
                                                     File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/vrtplayer.py", line 125, in show_favorites_menu
                                                       self._favorites.refresh(ttl=ttl('indirect'))
                                                     File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/favorites.py", line 40, in refresh
                                                       favorites_dict = self._generate_favorites_dict(self.get_favorites())
                                                     File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/favorites.py", line 88, in get_favorites
                                                       favorites_json = get_url_json(url='{}?{}'.format(self.FAVORITES_REST_URL, querystring), cache=None, headers=headers, raise_errors='all')
                                                     File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/kodiutils.py", line 1185, in get_url_json
                                                       response = open_url(url, headers=headers, data=data, raise_errors=raise_errors)
                                                     File "/storage/.kodi/addons/plugin.video.vrt.nu/resources/lib/kodiutils.py", line 1164, in open_url
                                                       log_error('Timeout: {error}\nurl: {url}', error=exc.reason, url=url)
                                                   AttributeError: 'timeout' object has no attribute 'reason'
                                                   -->End of Python script error report<--

2022-02-15 22:24:29.753 T:1214     INFO <general>: Python interpreter stopped
2022-02-15 22:24:29.764 T:1247     INFO <general>: Skipped 1 duplicate messages..
2022-02-15 22:24:29.764 T:1247    ERROR <general>: GetDirectory - Error getting plugin://plugin.video.vrt.nu/favorites
2022-02-15 22:24:29.788 T:978     ERROR <general>: CGUIMediaWindow::GetDirectory(plugin://plugin.video.vrt.nu/favorites) failed
```