### PR TITLE
fix resumepoints

### DIFF
--- a/resources/lib/api.py
+++ b/resources/lib/api.py
@@ -196,10 +196,12 @@ def resumepoints_is_activated():
 
 def get_resumepoint_data(episode_id):
     """Get resumepoint data from GraphQL API"""
+    if not episode_id:
+        return None
     data_json = get_stream_data(episode_id)
     return next(
         (mode.get('resumePointTemplate', {})
-         for mode in data_json.get('data', {}).get('page', {}).get('player', {}).get('modes', [])
+         for mode in (data_json.get('data', {}).get('page') or {}).get('player', {}).get('modes', [])
          if mode.get('__typename') == 'VideoPlayerMode'),
         None
     )
@@ -304,6 +306,11 @@ def get_stream_data(page_id):
                 subtitle
                 image {
                   templateUrl
+                }
+                progress {
+                  durationInSeconds
+                  progressInSeconds
+                  completed
                 }
                 modes {
                   ... on VideoPlayerMode {

--- a/resources/lib/playerinfo.py
+++ b/resources/lib/playerinfo.py
@@ -72,8 +72,8 @@ class PlayerInfo(Player, object):  # pylint: disable=useless-object-inheritance
                 return
 
         # Get resumepoint data
-        episode_id = '/' + self.path.split('//')[1]
-        resumepoint_data = get_resumepoint_data(episode_id=episode_id)
+        episode_id = '/vrtmax' + self.path.split('//vrtmax', 1)[1] if '//vrtmax' in self.path else None
+        resumepoint_data = get_resumepoint_data(episode_id=episode_id) or {}
         self.video_id = resumepoint_data.get('mediaId')
         self.resumepoint_title = resumepoint_data.get('mediaName')
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,7 +119,7 @@ class TestApi(unittest.TestCase):
 
     def test_upnext(self):
         """Test getting next episode (de-ideale-wereld)"""
-        episode_id = '/vrtmax/a-z/de-ideale-wereld/2025-vj/de-ideale-wereld-d20250430-a31/'
+        episode_id = '/vrtmax/a-z/de-ideale-wereld/2026-vj/de-ideale-wereld-d20260430-a40/'
         next_episode = get_next_info(episode_id).get('next_episode')
         self.assertTrue(next_episode)
         print(next_episode)


### PR DESCRIPTION
I switch between Kodi and browser sometimes so it's useful to be able to resume between one and the other.

It seems the extraction of the episode_id from the path was the main issue. Tested locally and confirmed working now.

(I also started fixing tests, but it seems some were failing on master, so I just committed the one I had fixed by then, no new test failures introduced)